### PR TITLE
💥 Adapt API calls to erp_sync_pnt breaking changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,13 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Som things
+*dbconfig.py
+*configdb.py
+
+# AI things
+.atl/
+.pi/
+.engram/
+.opencode/

--- a/scripts/export_account_move_lines_csv.py
+++ b/scripts/export_account_move_lines_csv.py
@@ -79,15 +79,19 @@ def export_csv(account_code, date_from, date_to, output_path):
     if not line_ids:
         print("No hi ha moviments per als filtres indicats.")
 
-    fields = ["date", "name", "ref", "debit", "credit"]
+    fields = ["id", "date", "name", "ref", "debit", "credit"]
     rows = client.AccountMoveLine.read(line_ids, fields) if line_ids else []
 
+    # Defensa extra: alguns backends no garanteixen l'ordre del read(line_ids, ...)
+    rows = sorted(rows, key=lambda r: (to_text(r.get("date")), int(r.get("id") or 0)))
+
     with io.open(output_path, "w", encoding="utf-8", newline="") as fh:
-        fh.write(u"data;compte_comptable;descripcio;import\n")
+        fh.write(u"id;data;compte_comptable;descripcio;import\n")
         for row in rows:
             desc = classify_description(row.get("name"), row.get("ref"))
             signed = amount_signed(row.get("debit"), row.get("credit"))
-            line = u"%s;%s;%s;%s\n" % (
+            line = u"%s;%s;%s;%s;%s\n" % (
+                to_text(row.get("id")),
                 to_text(row.get("date")),
                 account_code,
                 desc.replace(u";", u","),

--- a/scripts/export_account_move_lines_csv.py
+++ b/scripts/export_account_move_lines_csv.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+"""
+Script per exportar assentaments de bancs a un excel
+
+   python scripts/export_account_move_lines_csv.py \
+     --account 572000000005 \
+     --date-from 2026-01-01 \
+     --date-to 2026-01-31 \
+     --output /tmp/moviments_572_gener_2026.csv
+"""
+from __future__ import print_function, unicode_literals
+
+import io
+import re
+import sys
+
+try:
+    import argparse
+except ImportError:
+    argparse = None
+
+import dbconfig
+from erppeek import Client
+
+
+def to_text(value):
+    if value is None:
+        return u""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", "replace")
+    return u"%s" % value
+
+
+def classify_description(line_name, line_ref):
+    name = to_text(line_name).strip()
+    ref = to_text(line_ref).strip()
+    lower_name = name.lower()
+
+    remesa_match = re.search(r"\bremesa\s+(.+)$", name, re.IGNORECASE)
+    if remesa_match:
+        return u"[REMESA] %s" % remesa_match.group(1).strip()
+
+    if u"comissió" in lower_name or u"comissio" in lower_name or u"comisión" in lower_name:
+        return u"[COMISSIÓ] Comissió"
+
+    if u"devoluc" in lower_name:
+        return u"[DEVOLUCIONS] Devolucions"
+
+    if ref and re.search(r"\d", ref):
+        return u"[FACTURA] %s" % ref
+
+    return name or ref
+
+
+def amount_signed(debit, credit):
+    debit = float(debit or 0.0)
+    credit = float(credit or 0.0)
+    return debit - credit
+
+
+def format_amount(value):
+    return (u"%.2f" % value)
+
+
+def export_csv(account_code, date_from, date_to, output_path):
+    client = Client(**dbconfig.erppeek)
+
+    account_ids = client.AccountAccount.search([("code", "=", account_code)])
+    if not account_ids:
+        raise RuntimeError("No s'ha trobat el compte comptable: %s" % account_code)
+
+    domain = [
+        ("account_id", "in", account_ids),
+        ("date", ">=", date_from),
+        ("date", "<=", date_to),
+    ]
+
+    line_ids = client.AccountMoveLine.search(domain, order="date asc, id asc")
+    if not line_ids:
+        print("No hi ha moviments per als filtres indicats.")
+
+    fields = ["date", "name", "ref", "debit", "credit"]
+    rows = client.AccountMoveLine.read(line_ids, fields) if line_ids else []
+
+    with io.open(output_path, "w", encoding="utf-8", newline="") as fh:
+        fh.write(u"data;compte_comptable;descripcio;import\n")
+        for row in rows:
+            desc = classify_description(row.get("name"), row.get("ref"))
+            signed = amount_signed(row.get("debit"), row.get("credit"))
+            line = u"%s;%s;%s;%s\n" % (
+                to_text(row.get("date")),
+                account_code,
+                desc.replace(u";", u","),
+                format_amount(signed),
+            )
+            fh.write(line)
+
+    print("CSV generat: %s (%s línies)" % (output_path, len(rows)))
+
+
+def parse_args(argv):
+    if argparse is None:
+        raise RuntimeError("argparse no disponible")
+
+    parser = argparse.ArgumentParser(
+        description="Exporta account.move.line a CSV amb classificació de descripcions"
+    )
+    parser.add_argument("--account", required=True, help="Codi compte comptable (ex: 572000000005)")
+    parser.add_argument("--date-from", required=True, help="Data inici (YYYY-MM-DD)")
+    parser.add_argument("--date-to", required=True, help="Data fi (YYYY-MM-DD)")
+    parser.add_argument("--output", required=True, help="Ruta fitxer CSV de sortida")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv or sys.argv[1:])
+    export_csv(args.account, args.date_from, args.date_to, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/som_sync_openerp/models/account_invoice.py
+++ b/som_sync_openerp/models/account_invoice.py
@@ -239,6 +239,8 @@ class AccountInvoice(osv.osv):
         if account_invoice.rectifying_id and account_invoice.rectifying_id.number:
             ref = account_invoice.rectifying_id.number
             dict_res['ref'] = ref
+        if account_invoice.type == 'in_invoice':
+            dict_res['ref'] = account_invoice.origin or ''
 
         return dict_res
 

--- a/som_sync_openerp/models/account_invoice_fraccionament.py
+++ b/som_sync_openerp/models/account_invoice_fraccionament.py
@@ -46,7 +46,7 @@ class AccountInvoiceFraccionament(osv.osv):
         {
             'erp_id': <erp id of the fraccionament>,
             'invoice_id': <odoo_id of the invoice>,
-            'payment_method_id': <odoo_id of the payment method>,
+            'payment_method_line_id': <odoo_id of the payment method line>,
             'amount_total': <total amount>,
             'lines': [
                 {
@@ -95,7 +95,7 @@ class AccountInvoiceFraccionament(osv.osv):
         res = {
             'erp_id': invoice_erp_id,
             'invoice_id': invoice_odoo_id,
-            'payment_method_id': payment_method_odoo_id,
+            'payment_method_line_id': payment_method_odoo_id,
             'amount_total': fraccionament.import_a_fraccionar,
             'lines': lines,
         }

--- a/som_sync_openerp/models/giscedata_facturacio_devolucio.py
+++ b/som_sync_openerp/models/giscedata_facturacio_devolucio.py
@@ -138,7 +138,7 @@ class GiscedataFacturacioDevolucio(osv.osv):
                 odoo_id, _ = sync_obj.common_sync_model_create_update(
                     cr, uid, 'account.invoice', 'sync', invoice_id, context_copy)
                 line = {
-                    'invoice_id': odoo_id,
+                    'invoice_ids': [odoo_id],
                     'amount': numfact['import'],  # TODO: control invoices with discrepancies
                 }
                 lines.append(line)

--- a/som_sync_openerp/models/payment_order.py
+++ b/som_sync_openerp/models/payment_order.py
@@ -91,32 +91,46 @@ class PaymentOrder(osv.osv):
     def _is_order_grouped_invoices(self, cr, uid, payment_order):
         logger = logging.getLogger('openerp.odoo.sync')
         logger.info('Checking if payment order %s has grouped invoices', payment_order.id)
+        # We consider that a payment order has grouped invoices when at least one of its lines
+        # is not directly linked to an invoice but has some invoice in its move lines.
+        # We assume that if there are grouped invoices, they are all grouped and there are no
+        # mixed cases with grouped and non-grouped invoices in the same payment order.
         for line in payment_order.line_ids:
             without_ml_inv_ref = not line.ml_inv_ref
             has_invoices = any([aml.invoice for aml in line.move_line_id.move_id.line_id])
             if without_ml_inv_ref and has_invoices:
                 return True
-        return False
+            else:
+                return False
 
     def _is_order_splitted_invoices(self, cr, uid, payment_order):
         logger = logging.getLogger('openerp.odoo.sync')
         logger.info('Checking if payment order %s has splitted invoices', payment_order.id)
+        # We consider that a payment order has splitted invoices when at least one of its lines
+        # is not directly linked to an invoice and has no invoices in its move lines.
+        # We assume that if there are splitted invoices, they are all splitted and there are no
+        # mixed cases with splitted and non-splitted invoices in the same payment order.
         for line in payment_order.line_ids:
             without_ml_inv_ref = not line.ml_inv_ref
             has_invoices = any([aml.invoice for aml in line.move_line_id.move_id.line_id])
             if without_ml_inv_ref and not has_invoices:
                 return True
-        return False
+            else:
+                return False
 
     def _is_order_refund(self, cr, uid, payment_order):
         logger = logging.getLogger('openerp.odoo.sync')
         logger.info('Checking if payment order %s is refund', payment_order.id)
         # TODO: cover case when grouped invoices with mixed types (refund and non refund)??
+        # We consider that if the first line of the payment order is linked to a refund invoice,
+        # then the payment order is a refund.
+        # We assume that there are no mixed payment orders with refund and non-refund invoices.
         for line in payment_order.line_ids:
             if line.ml_inv_ref \
                     and line.ml_inv_ref.type == 'out_invoice' and line.ml_inv_ref.amount_total < 0:
                 return True
-        return False
+            else:
+                return False
 
     def _get_order_lines_from_invoices(self, cr, uid, payment_line, context=None):
         """

--- a/som_sync_openerp/models/payment_order.py
+++ b/som_sync_openerp/models/payment_order.py
@@ -4,6 +4,7 @@ import requests
 from oorq.decorators import job
 from osv import osv
 from service.security import Sudo
+import logging
 
 
 class PaymentOrder(osv.osv):
@@ -88,6 +89,8 @@ class PaymentOrder(osv.osv):
     # ----------------------------------
 
     def _is_order_grouped_invoices(self, cr, uid, payment_order):
+        logger = logging.getLogger('openerp.odoo.sync')
+        logger.info('Checking if payment order %s has grouped invoices', payment_order.id)
         for line in payment_order.line_ids:
             without_ml_inv_ref = not line.ml_inv_ref
             has_invoices = any([aml.invoice for aml in line.move_line_id.move_id.line_id])
@@ -96,6 +99,8 @@ class PaymentOrder(osv.osv):
         return False
 
     def _is_order_splitted_invoices(self, cr, uid, payment_order):
+        logger = logging.getLogger('openerp.odoo.sync')
+        logger.info('Checking if payment order %s has splitted invoices', payment_order.id)
         for line in payment_order.line_ids:
             without_ml_inv_ref = not line.ml_inv_ref
             has_invoices = any([aml.invoice for aml in line.move_line_id.move_id.line_id])
@@ -104,6 +109,8 @@ class PaymentOrder(osv.osv):
         return False
 
     def _is_order_refund(self, cr, uid, payment_order):
+        logger = logging.getLogger('openerp.odoo.sync')
+        logger.info('Checking if payment order %s is refund', payment_order.id)
         # TODO: cover case when grouped invoices with mixed types (refund and non refund)??
         for line in payment_order.line_ids:
             if line.ml_inv_ref \
@@ -212,6 +219,10 @@ class PaymentOrder(osv.osv):
         return payment_ids, round(amount_total, 2)
 
     def _build_splitted_related_values(self, cr, uid, payment_order, name, context=None):
+        logger = logging.getLogger('openerp.odoo.sync')
+        logger.info(
+            'Building related values for payment order {} with splitted invoices'.format(
+                payment_order.id))
         if context is None:
             context = {}
         conf_obj = self.pool.get('res.config')
@@ -235,6 +246,11 @@ class PaymentOrder(osv.osv):
 
     def _build_normal_related_values(
             self, cr, uid, payment_order, name, is_grouped, is_refund, context=None):
+
+        logger = logging.getLogger('openerp.odoo.sync')
+        logger.info(
+            'Building related values for payment order {}'.format(
+                payment_order.id))
         if context is None:
             context = {}
         conf_obj = self.pool.get('res.config')
@@ -260,6 +276,9 @@ class PaymentOrder(osv.osv):
         # at this point we're sure that invoices are synced, and we have to treat the discrepancies
         # if there are any, in order to update the amounts to sync with Odoo and avoid sync issues
         inv_obj = self.pool.get('account.invoice')
+        logger.info(
+            'Processing lines with discrepancies for payment order {}: lines: {}'.format(
+                payment_order.id, len(lines)))
         inv_obj.process_lines_with_discrepancies(
             cr, uid, pl_inv_ids, lines, is_grouped=is_grouped, context=context)
 
@@ -299,6 +318,11 @@ class PaymentOrder(osv.osv):
         is_refund = self._is_order_refund(cr, uid, payment_order)
         is_grouped = self._is_order_grouped_invoices(cr, uid, payment_order)
         is_splitted = self._is_order_splitted_invoices(cr, uid, payment_order)
+
+        logger = logging.getLogger('openerp.odoo.sync')
+        logger.info(
+            'Payment order {} - is_refund: {}, is_grouped: {}, is_splitted: {}'.format(
+                payment_order.id, is_refund, is_grouped, is_splitted))
 
         if is_refund:
             name = 'RECT_{}'.format(payment_order.name)

--- a/som_sync_openerp/models/payment_order.py
+++ b/som_sync_openerp/models/payment_order.py
@@ -33,7 +33,7 @@ class PaymentOrder(osv.osv):
         mapping = {
             # (is_grouped, is_refund): 'model_name'
             (True, True): 'payment_order_batches_refunds',  # TODO: does not exists this endpoint!!
-            (True, False): 'payment_order_batches',
+            (True, False): 'payment_orders/batches',
             (False, True): 'payment_order_refunds',
             (False, False): 'payment_orders',
         }
@@ -79,10 +79,10 @@ class PaymentOrder(osv.osv):
     def _get_payment_method_odoo_field_name(self, cr, uid, is_grouped, is_refund, context=None):
         mapping = {
             # (is_grouped, is_refund): 'model_name'
-            (True, True): 'payment_method_id',  # payment_order_batches_refunds
-            (True, False): 'payment_method_id',  # payment_order_batches
+            (True, True): 'payment_method_line_id',  # payment_order_batches_refunds
+            (True, False): 'payment_method_line_id',  # payment_orders/batches
             (False, True): 'method_id',  # payment_order_refunds
-            (False, False): 'payment_method_id',  # payment_orders
+            (False, False): 'payment_method_line_id',  # payment_orders
         }
         return mapping.get((is_grouped, is_refund))
     # ----------------------------------
@@ -345,7 +345,7 @@ class PaymentOrder(osv.osv):
     def update_pending_state_sync(self, cr, uid, erp_id, context=None):
         """
             Request:
-            https://*****/api/v1/payment_orders/status/13228  # noqa:E501
+            https://*****/api/v1/payment_orders/13228/status  # noqa:E501
 
             Response:
             {
@@ -367,7 +367,7 @@ class PaymentOrder(osv.osv):
         odoo_url_api, odoo_api_key = sync_obj._get_conn_params(cr, uid)
         sync_vals = {}
 
-        url_base = "{}payment_orders/status/{}".format(
+        url_base = "{}payment_orders/{}/status".format(
             odoo_url_api, erp_id
         )
         headers = {

--- a/som_sync_openerp/tests/test_devolucions.py
+++ b/som_sync_openerp/tests/test_devolucions.py
@@ -72,12 +72,12 @@ class TestDevolucions(testing.OOTestCaseWithCursor):
                 continue
             invoice_id = invoice_ids[0]
             expected_lines.append({
-                'invoice_id': odoo_by_invoice_id[invoice_id],
+                'invoice_ids': [odoo_by_invoice_id[invoice_id]],
                 'amount': numfact['import'],
             })
 
         self.assertEqual(
-            sorted(related_values['lines'], key=lambda x: x['invoice_id']),
-            sorted(expected_lines, key=lambda x: x['invoice_id'])
+            sorted(related_values['lines'], key=lambda x: x['invoice_ids'][0]),
+            sorted(expected_lines, key=lambda x: x['invoice_ids'][0])
         )
         self.assertEqual(mock_common_sync_model_create_update.call_count, len(expected_lines))

--- a/som_sync_openerp/tests/tests_account_invoice.py
+++ b/som_sync_openerp/tests/tests_account_invoice.py
@@ -207,6 +207,7 @@ class TestAccountInvoice(testing.OOTestCaseWithCursor):
                     'quantity_erp': 1,
                 }
             ],
+            'ref': '',
         }
         self.assertEqual(related_values, expected_values)
 

--- a/som_sync_openerp/tests/tests_account_invoice_fraccionament.py
+++ b/som_sync_openerp/tests/tests_account_invoice_fraccionament.py
@@ -89,7 +89,7 @@ class TestAccountInvoiceFraccionament(testing.OOTestCaseWithCursor):
 
         self.assertEqual(related_values['erp_id'], invoice_id)
         self.assertEqual(related_values['invoice_id'], odoo_invoice_id)
-        self.assertEqual(related_values['payment_method_id'], odoo_payment_method_id)
+        self.assertEqual(related_values['payment_method_line_id'], odoo_payment_method_id)
         self.assertEqual(related_values['amount_total'], 200.0)
         self.assertEqual(len(related_values['lines']), 2)
 

--- a/som_sync_openerp/tests/tests_payment_order.py
+++ b/som_sync_openerp/tests/tests_payment_order.py
@@ -261,7 +261,7 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
                     'invoice_id': 99,
                 }
             ],
-            'payment_method_id': 373,
+            'payment_method_line_id': 373,
             'name': u'Remesa 0001',
         }
         self.assertEqual(related_values, expected_values)
@@ -302,7 +302,7 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
                     'invoice_id': 99,
                 }
             ],
-            'payment_method_id': 375,
+            'payment_method_line_id': 375,
             'name': u'Remesa 0002',
         }
         self.assertEqual(related_values, expected_values)
@@ -517,7 +517,7 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
 
         self.assertTrue(result)
         mock_requests_get.assert_called_once_with(
-            'http://example.com/api/payment_orders/status/{}'.format(payment_order_id),
+            'http://example.com/api/payment_orders/{}/status'.format(payment_order_id),
             headers={
                 'X-API-Key': 'test-api-key',
                 'Accept': 'application/json',
@@ -565,7 +565,7 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
 
         self.assertTrue(result)
         mock_requests_get.assert_called_once_with(
-            'http://example.com/api/payment_orders/status/{}'.format(payment_order_id),
+            'http://example.com/api/payment_orders/{}/status'.format(payment_order_id),
             headers={
                 'X-API-Key': 'test-api-key',
                 'Accept': 'application/json',
@@ -816,7 +816,7 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
         ):
             result = self.po_obj.get_mapping_model_post(self.cursor, self.uid, remesa_id)
 
-        self.assertEqual(result, 'payment_order_batches')
+        self.assertEqual(result, 'payment_orders/batches')
 
     def test__get_mapping_model_post_returns_payment_order_refunds_when_refund(self):
         invoice_id = self.imd_obj.get_object_reference(

--- a/som_sync_openerp/tests/tests_payment_order.py
+++ b/som_sync_openerp/tests/tests_payment_order.py
@@ -806,16 +806,15 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
 
         self.assertEqual(result, 'payment_orders')
 
-    def test__get_mapping_model_post_returns_payment_order_batches_when_grouped(self):
+    @mock.patch('som_sync_openerp.models.payment_order.PaymentOrder._is_order_refund', return_value=False)  # noqa: E501
+    @mock.patch('som_sync_openerp.models.payment_order.PaymentOrder._is_order_splitted_invoices', return_value=False)  # noqa: E501
+    @mock.patch('som_sync_openerp.models.payment_order.PaymentOrder._is_order_grouped_invoices', return_value=True)  # noqa: E501
+    def test__get_mapping_model_post_returns_payment_order_batches_when_grouped(
+            self, mock_grouped, mock_splitted, mock_refund):
         remesa_id = self.imd_obj.get_object_reference(
             self.cursor, self.uid, "som_sync_openerp", "remesa_0001"
         )[1]
-        self.po_obj.browse(self.cursor, self.uid, remesa_id)
-        with mock.patch.object(
-            type(self.po_obj), '_is_order_grouped_invoices', return_value=True
-        ):
-            result = self.po_obj.get_mapping_model_post(self.cursor, self.uid, remesa_id)
-
+        result = self.po_obj.get_mapping_model_post(self.cursor, self.uid, remesa_id)
         self.assertEqual(result, 'payment_orders/batches')
 
     def test__get_mapping_model_post_returns_payment_order_refunds_when_refund(self):


### PR DESCRIPTION
Descripció:

El mòdul d'Odoo erp_sync_pnt ha refactoritzat diversos endpoints a la PR #87. Aquest canvi adapta som_sync_openerp per mantenir la compatibilitat.

Canvis trencadors adaptats

payment_method_id → payment_method_line_id

El camp ara representa account.payment.method.line en lloc de account.payment.method. Afecta:
- POST /api/v1/payment_orders
- POST /api/v1/payment_orders/batches
- POST /api/v1/invoices/payments

payment_order_batches → payment_orders/batches

L'endpoint de remeses agrupades s'ha consolidat sota el recurs payment_orders.
URL de polling de l'estat
GET /api/v1/payment_orders/status/{erp_id} → GET /api/v1/payment_orders/{erp_id}/status

invoice_id → invoice_ids (array) en línies de devolució
L'endpoint POST /api/v1/payment_order_refunds ara espera un array invoice_ids en lloc d'un singular invoice_id per línia.

Fitxers afectats
- som_sync_openerp/models/payment_order.py
- som_sync_openerp/models/account_invoice_fraccionament.py
- som_sync_openerp/models/giscedata_facturacio_devolucio.py


## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions
