### PR TITLE
🔨 Afegim script amb erppeek per executar la sincronització inicial de models mestres

### DIFF
--- a/scripts/massive_sync_models.py
+++ b/scripts/massive_sync_models.py
@@ -2,6 +2,10 @@
 """
 Script to launch the initial massive sync of ERP master models to Odoo.
 
+This script is intended to be executed directly from IPython, not imported as a module.
+
+It intentionally performs the sync at top level when loaded.
+
 Only non-static models should be included here. Static models such as
 account.journal, account.tax or payment.type are resolved through static
 odoo.sync mappings loaded from migration CSV files, not through the HTTP
@@ -60,11 +64,33 @@ MASTER_MODELS = [
 
 def sync_model(model_name, domain):
     ids_to_sync = O.model(model_name).search(domain)
+    failures = []
 
     print('Syncing %s records of model %s' % (len(ids_to_sync), model_name))
     for id in tqdm(ids_to_sync):
-        O.OdooSync.common_sync_model_create_update(model_name, 'sync', id)
+        try:
+            O.OdooSync.common_sync_model_create_update(model_name, 'sync', id)
+        except Exception as e:
+            failures.append((model_name, id, e))
+            print('Failed syncing %s %s: %s' % (model_name, id, e))
+
+    print(
+        'Finished %s: %s ok, %s failed' % (
+            model_name,
+            len(ids_to_sync) - len(failures),
+            len(failures),
+        )
+    )
+    return failures
 
 
+all_failures = []
 for master_model in MASTER_MODELS:
-    sync_model(master_model['model'], master_model['domain'])
+    all_failures.extend(sync_model(master_model['model'], master_model['domain']))
+
+if all_failures:
+    print('Sync finished with failures:')
+    for model_name, id, error in all_failures:
+        print('- %s %s: %s' % (model_name, id, error))
+else:
+    print('Sync finished without failures')

--- a/scripts/massive_sync_models.py
+++ b/scripts/massive_sync_models.py
@@ -14,8 +14,9 @@ create/update sync flow.
 The order of MASTER_MODELS is intentional:
 - account.account must be synced before res.partner because partners depend on
   receivable/payable accounts.
-- res.partner must be synced before res.partner.bank because bank accounts need
-  the partner odoo.sync mapping to build their endpoint suffix.
+- res.partner must be synced before res.partner.address and res.partner.bank
+  because both need the partner odoo.sync mapping to build their endpoint
+  suffix.
 
 Each model domain filters out records that cannot build a valid Odoo endpoint
 suffix, such as partners without VAT, states without country/REE code, or bank
@@ -50,6 +51,12 @@ MASTER_MODELS = [
         'model': 'res.partner',
         'domain': [
             ('vat', '!=', False),
+        ],
+    },
+    {
+        'model': 'res.partner.address',
+        'domain': [
+            ('partner_id', '!=', False),
         ],
     },
     {

--- a/scripts/massive_sync_models.py
+++ b/scripts/massive_sync_models.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+"""
+Script to launch the initial massive sync of ERP master models to Odoo.
+
+Only non-static models should be included here. Static models such as
+account.journal, account.tax or payment.type are resolved through static
+odoo.sync mappings loaded from migration CSV files, not through the HTTP
+create/update sync flow.
+
+The order of MASTER_MODELS is intentional:
+- account.account must be synced before res.partner because partners depend on
+  receivable/payable accounts.
+- res.partner must be synced before res.partner.bank because bank accounts need
+  the partner odoo.sync mapping to build their endpoint suffix.
+
+Each model domain filters out records that cannot build a valid Odoo endpoint
+suffix, such as partners without VAT, states without country/REE code, or bank
+accounts without IBAN.
+"""
+import erppeek
+from tqdm import tqdm
+
+O = erppeek.Client('http://localhost:1234', 'db', 'user')  # noqa: E741
+
+MASTER_MODELS = [
+    {
+        'model': 'account.account',
+        'domain': [
+            ('code', '!=', False),
+        ],
+    },
+    {
+        'model': 'res.country.state',
+        'domain': [
+            ('ree_code', '!=', False),
+            ('country_id', '!=', False),
+        ],
+    },
+    {
+        'model': 'res.municipi',
+        'domain': [
+            ('ine', '!=', False),
+        ],
+    },
+    {
+        'model': 'res.partner',
+        'domain': [
+            ('vat', '!=', False),
+        ],
+    },
+    {
+        'model': 'res.partner.bank',
+        'domain': [
+            ('partner_id', '!=', False),
+            ('iban', '!=', False),
+        ],
+    },
+]
+
+
+def sync_model(model_name, domain):
+    ids_to_sync = O.model(model_name).search(domain)
+
+    print('Syncing %s records of model %s' % (len(ids_to_sync), model_name))
+    for id in tqdm(ids_to_sync):
+        O.OdooSync.common_sync_model_create_update(model_name, 'sync', id)
+
+
+for master_model in MASTER_MODELS:
+    sync_model(master_model['model'], master_model['domain'])


### PR DESCRIPTION
## Objectiu
Poder sincronitzar massivament els models mestres a Odoo

## Targeta on es demana o Incidència
https://somenergia.openproject.com/wp/1708

## Comportament antic


## Comportament nou


## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a one-shot script (`scripts/massive_sync_models.py`) that uses erppeek to iterate over a fixed list of ERP master models (`account.account`, `res.country.state`, `res.municipi`, `res.partner`, `res.partner.bank`) and calls `OdooSync.common_sync_model_create_update` on each record that passes a domain filter, enabling a bulk initial sync from OpenERP to Odoo.

- The `erppeek.Client` connection on line 23 uses literal placeholder strings `'db'` and `'user'` and omits the `password` argument, which will prevent successful authentication; the existing sibling script uses `dbconfig.erppeek` for credentials and should be used as the model here.
- There is no per-record error handling in `sync_model`, so a single failed RPC call will abort the entire run mid-sync with no record of what succeeded.
- The execution loop at the bottom runs unconditionally on import; it should be wrapped in a `if __name__ == '__main__':` guard.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The script cannot connect to OpenERP as written because the credentials are literal placeholder strings and the password argument is missing; it would need fixes before it can be run safely.

The erppeek client is initialised with 'db' and 'user' as literal strings and no password, which means the script will fail at authentication before syncing a single record. Additionally, no per-record error handling means a single RPC failure mid-run would leave the sync in an unknown partial state with no diagnostic output.

scripts/massive_sync_models.py — specifically the erppeek client initialisation and the bare sync loop inside sync_model.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/massive_sync_models.py | New script for bulk-syncing ERP master models via erppeek; has hardcoded placeholder credentials and a missing password argument that will prevent the script from connecting, no per-record error handling, and no __main__ guard. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Script as massive_sync_models.py
    participant ERP as OpenERP (erppeek)
    participant Odoo as Odoo (OdooSync)

    Script->>ERP: erppeek.Client(localhost:18069, db, user)
    ERP-->>Script: Client O

    loop each model in MASTER_MODELS
        Script->>ERP: O.model(model_name).search(domain)
        ERP-->>Script: ids_to_sync[]

        loop each id
            Script->>ERP: O.OdooSync.common_sync_model_create_update(model_name, 'sync', id)
            ERP->>Odoo: HTTP create/update sync
            Odoo-->>ERP: response
            ERP-->>Script: result
        end
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["🔨 add massive master model sync script"](https://github.com/som-energia/som_sync_openerp_modules/commit/87b069329efda65a6e4ac1b9a16e3244e317ce15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35815419)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->