### PR TITLE
Resoldre diari de banc per remeses

### DIFF
--- a/som_sync_openerp/demo/odoo_sync_demo.xml
+++ b/som_sync_openerp/demo/odoo_sync_demo.xml
@@ -61,6 +61,7 @@
             <field name="type">general</field>
             <field name="som_sync_odoo_account_moves">True</field>
             <field name="som_sync_odoo_invoices">False</field>
+            <field name="som_sync_bank_id" ref="base.res_partner_bank_0001"/>
             <field name="view_id" ref="account.account_journal_view"/>
             <field name="sequence_id" ref="account.sequence_journal"/>
         </record>
@@ -79,6 +80,7 @@
             <field name="type">purchase</field>
             <field name="som_sync_odoo_invoices">True</field>
             <field name="som_sync_odoo_account_moves">False</field>
+            <field name="som_sync_bank_id" ref="base.res_partner_bank_0002"/>
             <field name="view_id" ref="account.account_journal_view"/>
             <field name="sequence_id" ref="account.sequence_journal"/>
         </record>

--- a/som_sync_openerp/demo/odoo_sync_demo.xml
+++ b/som_sync_openerp/demo/odoo_sync_demo.xml
@@ -61,7 +61,7 @@
             <field name="type">general</field>
             <field name="som_sync_odoo_account_moves">True</field>
             <field name="som_sync_odoo_invoices">False</field>
-            <field name="som_sync_bank_id" ref="base.res_partner_bank_0001"/>
+            <field name="company_bank_id" ref="base.res_partner_bank_0001"/>
             <field name="view_id" ref="account.account_journal_view"/>
             <field name="sequence_id" ref="account.sequence_journal"/>
         </record>
@@ -80,7 +80,7 @@
             <field name="type">purchase</field>
             <field name="som_sync_odoo_invoices">True</field>
             <field name="som_sync_odoo_account_moves">False</field>
-            <field name="som_sync_bank_id" ref="base.res_partner_bank_0002"/>
+            <field name="company_bank_id" ref="base.res_partner_bank_0002"/>
             <field name="view_id" ref="account.account_journal_view"/>
             <field name="sequence_id" ref="account.sequence_journal"/>
         </record>

--- a/som_sync_openerp/migrations/5.0.25.5.0/post-0003_add_journal_bank_field.py
+++ b/som_sync_openerp/migrations/5.0.25.5.0/post-0003_add_journal_bank_field.py
@@ -16,7 +16,7 @@ def up(cursor, installed_version):
     logger.info("Creating pooler")
     pool = pooler.get_pool(cursor.dbname)
 
-    logger.info("Creating new field som_sync_bank_id on model account.journal")
+    logger.info("Creating new field company_bank_id on model account.journal")
     pool.get('account.journal')._auto_init(
         cursor, context={'module': 'som_sync_openerp'}
     )

--- a/som_sync_openerp/migrations/5.0.25.5.0/post-0003_add_journal_bank_field.py
+++ b/som_sync_openerp/migrations/5.0.25.5.0/post-0003_add_journal_bank_field.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+import logging
+import pooler
+
+from oopgrade.oopgrade import load_data
+from tools import config
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+    if config.updating_all:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+    logger.info("Creating pooler")
+    pool = pooler.get_pool(cursor.dbname)
+
+    logger.info("Creating new field som_sync_bank_id on model account.journal")
+    pool.get('account.journal')._auto_init(
+        cursor, context={'module': 'som_sync_openerp'}
+    )
+    logger.info("Field created successfully")
+
+    logger.info("Updating XML views/account_journal_view.xml")
+    load_data(
+        cursor,
+        'som_sync_openerp',
+        'views/account_journal_view.xml',
+        idref=None,
+        mode='update'
+    )
+    logger.info("XMLs succesfully updated.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_sync_openerp/models/account_journal.py
+++ b/som_sync_openerp/models/account_journal.py
@@ -13,6 +13,9 @@ class AccountJournal(osv.osv):
         'som_sync_odoo_invoices': fields.boolean(
             'Sync with Odoo Invoices',
             help='If checked, this journal will be synchronize Invoices with Odoo.'),
+        'som_sync_bank_id': fields.many2one(
+            'res.partner.bank', 'Bank account for Odoo sync',
+            help='Bank account used to resolve the Odoo journal for payment order sync.'),
     }
 
     _defaults = {

--- a/som_sync_openerp/models/account_journal.py
+++ b/som_sync_openerp/models/account_journal.py
@@ -13,14 +13,14 @@ class AccountJournal(osv.osv):
         'som_sync_odoo_invoices': fields.boolean(
             'Sync with Odoo Invoices',
             help='If checked, this journal will be synchronize Invoices with Odoo.'),
-        'som_sync_company_partner_id': fields.related(
+        'company_partner_id': fields.related(
             'company_id', 'partner_id',
             type='many2one', relation='res.partner',
             string='Company Partner', readonly=True,
         ),
-        'som_sync_bank_id': fields.many2one(
+        'company_bank_id': fields.many2one(
             'res.partner.bank', 'Bank account for Odoo sync',
-            domain="[('partner_id', '=', som_sync_company_partner_id)]",
+            domain="[('partner_id', '=', company_partner_id)]",
             help='Bank account used to resolve the Odoo journal for payment order sync.'),
     }
 
@@ -28,6 +28,14 @@ class AccountJournal(osv.osv):
         'som_sync_odoo_account_moves': lambda *a, **k: False,
         'som_sync_odoo_invoices': lambda *a, **k: False,
     }
+
+    _sql_constraints = [
+        (
+            'company_bank_id_unique',
+            'unique(company_bank_id)',
+            'A bank account can only be linked to one journal.',
+        ),
+    ]
 
 
 AccountJournal()

--- a/som_sync_openerp/models/account_journal.py
+++ b/som_sync_openerp/models/account_journal.py
@@ -13,8 +13,14 @@ class AccountJournal(osv.osv):
         'som_sync_odoo_invoices': fields.boolean(
             'Sync with Odoo Invoices',
             help='If checked, this journal will be synchronize Invoices with Odoo.'),
+        'som_sync_company_partner_id': fields.related(
+            'company_id', 'partner_id',
+            type='many2one', relation='res.partner',
+            string='Company Partner', readonly=True,
+        ),
         'som_sync_bank_id': fields.many2one(
             'res.partner.bank', 'Bank account for Odoo sync',
+            domain="[('partner_id', '=', som_sync_company_partner_id)]",
             help='Bank account used to resolve the Odoo journal for payment order sync.'),
     }
 

--- a/som_sync_openerp/models/payment_order.py
+++ b/som_sync_openerp/models/payment_order.py
@@ -96,29 +96,25 @@ class PaymentOrder(osv.osv):
         journal_obj = self.pool.get('account.journal')
 
         if not payment_order.mode or not payment_order.mode.bank_id:
-            logger.warning(
-                'Payment order %s has no payment mode bank configured',
-                payment_order.id,
-            )
-            return False
+            msg = 'Payment order {} has no payment mode bank configured'.format(payment_order.id)
+            logger.warning(msg)
+            raise Exception(msg)
 
         journal_ids = journal_obj.search(
             cr, uid, [('company_bank_id', '=', payment_order.mode.bank_id.id)],
             context=context)
         if not journal_ids:
-            logger.warning(
-                'No account.journal found for bank account %s in payment order %s',
-                payment_order.mode.bank_id.id, payment_order.id,
-            )
-            return False
+            msg = 'No account.journal found for bank account {} in payment order {}'.format(
+                payment_order.mode.bank_id.id, payment_order.id)
+            logger.warning(msg)
+            raise Exception(msg)
 
         journal_odoo_id = sync_obj.get_odoo_id_by_erp_id(
             cr, uid, 'account.journal', journal_ids[0])
         if not journal_odoo_id:
-            logger.warning(
-                'No Odoo mapping found for account.journal %s in payment order %s',
-                journal_ids[0], payment_order.id,
-            )
+            msg = 'No Odoo mapping found for account.journal {} in payment order {}'.format(
+                journal_ids[0], payment_order.id)
+            logger.warning(msg)
             raise ForeingKeyNotAvailable(
                 'account.journal,{}'.format(journal_ids[0])
             )

--- a/som_sync_openerp/models/payment_order.py
+++ b/som_sync_openerp/models/payment_order.py
@@ -102,7 +102,7 @@ class PaymentOrder(osv.osv):
             return False
 
         journal_ids = journal_obj.search(
-            cr, uid, [('som_sync_bank_id', '=', payment_order.mode.bank_id.id)],
+            cr, uid, [('company_bank_id', '=', payment_order.mode.bank_id.id)],
             context=context)
         if not journal_ids:
             logger.warning(

--- a/som_sync_openerp/models/payment_order.py
+++ b/som_sync_openerp/models/payment_order.py
@@ -4,6 +4,7 @@ import requests
 from oorq.decorators import job
 from osv import osv
 from service.security import Sudo
+from .odoo_exceptions import ForeingKeyNotAvailable
 import logging
 
 
@@ -118,7 +119,9 @@ class PaymentOrder(osv.osv):
                 'No Odoo mapping found for account.journal %s in payment order %s',
                 journal_ids[0], payment_order.id,
             )
-            return False
+            raise ForeingKeyNotAvailable(
+                'account.journal,{}'.format(journal_ids[0])
+            )
         return journal_odoo_id
     # ----------------------------------
 

--- a/som_sync_openerp/models/payment_order.py
+++ b/som_sync_openerp/models/payment_order.py
@@ -110,12 +110,6 @@ class PaymentOrder(osv.osv):
                 payment_order.mode.bank_id.id, payment_order.id,
             )
             return False
-        if len(journal_ids) > 1:
-            logger.warning(
-                'Multiple journal records found for bank account %s in payment order %s: %s',
-                payment_order.mode.bank_id.id, payment_order.id, journal_ids,
-            )
-            return False
 
         journal_odoo_id = sync_obj.get_odoo_id_by_erp_id(
             cr, uid, 'account.journal', journal_ids[0])

--- a/som_sync_openerp/models/payment_order.py
+++ b/som_sync_openerp/models/payment_order.py
@@ -102,12 +102,18 @@ class PaymentOrder(osv.osv):
             return False
 
         journal_ids = journal_obj.search(
-            cr, uid, [('som_sync_bank_id', '=', payment_order.mode.bank_id.id)], limit=1,
+            cr, uid, [('som_sync_bank_id', '=', payment_order.mode.bank_id.id)],
             context=context)
         if not journal_ids:
             logger.warning(
                 'No account.journal found for bank account %s in payment order %s',
                 payment_order.mode.bank_id.id, payment_order.id,
+            )
+            return False
+        if len(journal_ids) > 1:
+            logger.warning(
+                'Multiple journal records found for bank account %s in payment order %s: %s',
+                payment_order.mode.bank_id.id, payment_order.id, journal_ids,
             )
             return False
 

--- a/som_sync_openerp/models/payment_order.py
+++ b/som_sync_openerp/models/payment_order.py
@@ -86,6 +86,40 @@ class PaymentOrder(osv.osv):
             (False, False): 'payment_method_line_id',  # payment_orders
         }
         return mapping.get((is_grouped, is_refund))
+
+    def _get_journal_odoo_id(self, cr, uid, payment_order, context=None):
+        if context is None:
+            context = {}
+        logger = logging.getLogger('openerp.odoo.sync')
+        sync_obj = self.pool.get('odoo.sync')
+        journal_obj = self.pool.get('account.journal')
+
+        if not payment_order.mode or not payment_order.mode.bank_id:
+            logger.warning(
+                'Payment order %s has no payment mode bank configured',
+                payment_order.id,
+            )
+            return False
+
+        journal_ids = journal_obj.search(
+            cr, uid, [('som_sync_bank_id', '=', payment_order.mode.bank_id.id)], limit=1,
+            context=context)
+        if not journal_ids:
+            logger.warning(
+                'No account.journal found for bank account %s in payment order %s',
+                payment_order.mode.bank_id.id, payment_order.id,
+            )
+            return False
+
+        journal_odoo_id = sync_obj.get_odoo_id_by_erp_id(
+            cr, uid, 'account.journal', journal_ids[0])
+        if not journal_odoo_id:
+            logger.warning(
+                'No Odoo mapping found for account.journal %s in payment order %s',
+                journal_ids[0], payment_order.id,
+            )
+            return False
+        return journal_odoo_id
     # ----------------------------------
 
     def _is_order_grouped_invoices(self, cr, uid, payment_order):
@@ -241,9 +275,8 @@ class PaymentOrder(osv.osv):
             context = {}
         conf_obj = self.pool.get('res.config')
 
-        # TODO: we need to get to bank journal from the payment_mode,
-        # but it is not payment_order.mode.journal, by now harcoded
-        journal_odoo_id = 13
+        journal_odoo_id = self._get_journal_odoo_id(
+            cr, uid, payment_order, context=context)
         metode_pagament_id = eval(
             conf_obj.get(cr, uid, 'odoo_customer_fraccionaments_payment_method', 0))
 
@@ -269,9 +302,8 @@ class PaymentOrder(osv.osv):
             context = {}
         conf_obj = self.pool.get('res.config')
 
-        # TODO: we need to get to bank journal from the payment_mode,
-        # but it is not payment_order.mode.journal, by now harcoded
-        journal_odoo_id = 13
+        journal_odoo_id = self._get_journal_odoo_id(
+            cr, uid, payment_order, context=context)
         lines = []
         pl_inv_ids = []
 

--- a/som_sync_openerp/tests/__init__.py
+++ b/som_sync_openerp/tests/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 from .tests_account_account import *
+from .tests_account_journal import *
 from .tests_account_invoice import *
 from .tests_account_move import *
 from .tests_odoo_sync import *

--- a/som_sync_openerp/tests/tests_account_journal.py
+++ b/som_sync_openerp/tests/tests_account_journal.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from destral import testing
+
+
+class TestAccountJournal(testing.OOTestCaseWithCursor):
+
+    def setUp(self):
+        self.aj_obj = self.openerp.pool.get("account.journal")
+        self.imd_obj = self.openerp.pool.get("ir.model.data")
+        super(TestAccountJournal, self).setUp()
+
+    def test__company_bank_id_must_be_unique(self):
+        bank_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, "base", "res_partner_bank_0001"
+        )[1]
+        view_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, "account", "account_journal_view"
+        )[1]
+        sequence_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, "account", "sequence_journal"
+        )[1]
+
+        with self.assertRaises(Exception):
+            self.aj_obj.create(self.cursor, self.uid, {
+                'name': 'Duplicate bank journal',
+                'code': 'DupBank',
+                'type': 'general',
+                'company_bank_id': bank_id,
+                'view_id': view_id,
+                'sequence_id': sequence_id,
+            })

--- a/som_sync_openerp/tests/tests_payment_order.py
+++ b/som_sync_openerp/tests/tests_payment_order.py
@@ -226,6 +226,56 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
         return fracc_id
 
     @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id")
+    def test__get_journal_odoo_id_uses_payment_mode_bank(self, mock_get_odoo_id_by_erp_id):
+        remesa_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, "som_sync_openerp", "remesa_0001"
+        )[1]
+        journal_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, "som_sync_openerp", "account_journal_syncronizable"
+        )[1]
+        payment_order = self.po_obj.browse(self.cursor, self.uid, remesa_id)
+        mock_get_odoo_id_by_erp_id.return_value = 13
+
+        journal_odoo_id = self.po_obj._get_journal_odoo_id(
+            self.cursor, self.uid, payment_order
+        )
+
+        self.assertEqual(journal_odoo_id, 13)
+        mock_get_odoo_id_by_erp_id.assert_called_once_with(
+            self.cursor, self.uid, 'account.journal', journal_id)
+
+    @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id")
+    def test__get_journal_odoo_id_returns_false_when_payment_mode_has_no_bank(
+            self, mock_get_odoo_id_by_erp_id):
+        remesa_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, "som_sync_openerp", "remesa_0001"
+        )[1]
+        payment_order = self.po_obj.browse(self.cursor, self.uid, remesa_id)
+        with mock.patch.object(payment_order, 'mode', False, create=True):
+            journal_odoo_id = self.po_obj._get_journal_odoo_id(
+                self.cursor, self.uid, payment_order
+            )
+
+        self.assertFalse(journal_odoo_id)
+        mock_get_odoo_id_by_erp_id.assert_not_called()
+
+    @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id")
+    def test__get_journal_odoo_id_returns_false_when_journal_has_no_odoo_mapping(
+            self, mock_get_odoo_id_by_erp_id):
+        remesa_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, "som_sync_openerp", "remesa_0001"
+        )[1]
+        payment_order = self.po_obj.browse(self.cursor, self.uid, remesa_id)
+        mock_get_odoo_id_by_erp_id.return_value = False
+
+        journal_odoo_id = self.po_obj._get_journal_odoo_id(
+            self.cursor, self.uid, payment_order
+        )
+
+        self.assertFalse(journal_odoo_id)
+        mock_get_odoo_id_by_erp_id.assert_called_once()
+
+    @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id")
     @mock.patch.object(odoo_sync.OdooSync, "get_erp_id_by_odoo_id")
     @mock.patch.object(odoo_sync.OdooSync, "common_sync_model_create_update")
     def test__get_related_values_inbound(self, mock_syncronize_sync, mock_erp_id, mock_odoo_id):
@@ -307,10 +357,11 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
         }
         self.assertEqual(related_values, expected_values)
 
+    @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id")
     @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id_from_odoo")
     @mock.patch.object(odoo_sync.OdooSync, "common_sync_model_create_update")
     def test__get_related_values_splitted_returns_payment_ids_and_amount(
-            self, mock_sync_create_update, mock_get_odoo_id):
+            self, mock_sync_create_update, mock_get_odoo_id, mock_get_odoo_id_by_erp_id):
         remesa_id = self.imd_obj.get_object_reference(
             self.cursor, self.uid, "som_sync_openerp", "remesa_0001"
         )[1]
@@ -323,6 +374,7 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
 
         mock_sync_create_update.return_value = (999, 1)
         mock_get_odoo_id.side_effect = [odoo_payment_id_1, odoo_payment_id_2]
+        mock_get_odoo_id_by_erp_id.return_value = 13
 
         self.utils_create_fraccionament_in_order(remesa_id, import_amount=300.0)
         self.utils_create_fraccionament_in_order(remesa_id, import_amount=200.0)
@@ -340,15 +392,17 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
         }
         self.assertEqual(related_values, expected_values)
 
+    @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id")
     @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id_from_odoo")
     @mock.patch.object(odoo_sync.OdooSync, "common_sync_model_create_update")
     def test__get_related_values_splitted_amount_is_rounded(
-            self, mock_sync_create_update, mock_get_odoo_id):
+            self, mock_sync_create_update, mock_get_odoo_id, mock_get_odoo_id_by_erp_id):
         remesa_id = self.imd_obj.get_object_reference(
             self.cursor, self.uid, "som_sync_openerp", "remesa_0001"
         )[1]
         mock_sync_create_update.return_value = (999, 1)
         mock_get_odoo_id.return_value = 999
+        mock_get_odoo_id_by_erp_id.return_value = 13
 
         self.utils_create_fraccionament_in_order(remesa_id, import_amount=100.005)
         self.utils_create_fraccionament_in_order(remesa_id, import_amount=100.005)

--- a/som_sync_openerp/tests/tests_payment_order.py
+++ b/som_sync_openerp/tests/tests_payment_order.py
@@ -302,7 +302,7 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
             'name': 'Duplicate bank journal',
             'code': 'DupBank',
             'type': 'general',
-            'som_sync_bank_id': payment_order.mode.bank_id.id,
+            'company_bank_id': payment_order.mode.bank_id.id,
             'view_id': self.imd_obj.get_object_reference(
                 self.cursor, self.uid, 'account', 'account_journal_view'
             )[1],

--- a/som_sync_openerp/tests/tests_payment_order.py
+++ b/som_sync_openerp/tests/tests_payment_order.py
@@ -292,6 +292,33 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
         mock_get_odoo_id_by_erp_id.assert_not_called()
 
     @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id")
+    def test__get_journal_odoo_id_returns_false_when_multiple_journals_match_bank(
+            self, mock_get_odoo_id_by_erp_id):
+        remesa_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, "som_sync_openerp", "remesa_0001"
+        )[1]
+        payment_order = self.po_obj.browse(self.cursor, self.uid, remesa_id)
+        self.aj_obj.create(self.cursor, self.uid, {
+            'name': 'Duplicate bank journal',
+            'code': 'DupBank',
+            'type': 'general',
+            'som_sync_bank_id': payment_order.mode.bank_id.id,
+            'view_id': self.imd_obj.get_object_reference(
+                self.cursor, self.uid, 'account', 'account_journal_view'
+            )[1],
+            'sequence_id': self.imd_obj.get_object_reference(
+                self.cursor, self.uid, 'account', 'sequence_journal'
+            )[1],
+        })
+
+        journal_odoo_id = self.po_obj._get_journal_odoo_id(
+            self.cursor, self.uid, payment_order
+        )
+
+        self.assertFalse(journal_odoo_id)
+        mock_get_odoo_id_by_erp_id.assert_not_called()
+
+    @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id")
     @mock.patch.object(odoo_sync.OdooSync, "get_erp_id_by_odoo_id")
     @mock.patch.object(odoo_sync.OdooSync, "common_sync_model_create_update")
     def test__get_related_values_inbound(self, mock_syncronize_sync, mock_erp_id, mock_odoo_id):

--- a/som_sync_openerp/tests/tests_payment_order.py
+++ b/som_sync_openerp/tests/tests_payment_order.py
@@ -5,6 +5,7 @@ from destral.patch import PatchNewCursors
 import mock
 import netsvc
 from ..models import odoo_sync
+from ..models.odoo_exceptions import ForeingKeyNotAvailable
 import unittest
 
 
@@ -260,7 +261,7 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
         mock_get_odoo_id_by_erp_id.assert_not_called()
 
     @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id")
-    def test__get_journal_odoo_id_returns_false_when_journal_has_no_odoo_mapping(
+    def test__get_journal_odoo_id_raises_when_journal_has_no_odoo_mapping(
             self, mock_get_odoo_id_by_erp_id):
         remesa_id = self.imd_obj.get_object_reference(
             self.cursor, self.uid, "som_sync_openerp", "remesa_0001"
@@ -268,11 +269,10 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
         payment_order = self.po_obj.browse(self.cursor, self.uid, remesa_id)
         mock_get_odoo_id_by_erp_id.return_value = False
 
-        journal_odoo_id = self.po_obj._get_journal_odoo_id(
-            self.cursor, self.uid, payment_order
-        )
-
-        self.assertFalse(journal_odoo_id)
+        with self.assertRaises(ForeingKeyNotAvailable):
+            self.po_obj._get_journal_odoo_id(
+                self.cursor, self.uid, payment_order
+            )
         mock_get_odoo_id_by_erp_id.assert_called_once()
 
     @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id")

--- a/som_sync_openerp/tests/tests_payment_order.py
+++ b/som_sync_openerp/tests/tests_payment_order.py
@@ -246,18 +246,18 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
             self.cursor, self.uid, 'account.journal', journal_id)
 
     @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id")
-    def test__get_journal_odoo_id_returns_false_when_payment_mode_has_no_bank(
+    def test__get_journal_odoo_id_raises_when_payment_mode_has_no_bank(
             self, mock_get_odoo_id_by_erp_id):
         remesa_id = self.imd_obj.get_object_reference(
             self.cursor, self.uid, "som_sync_openerp", "remesa_0001"
         )[1]
         payment_order = self.po_obj.browse(self.cursor, self.uid, remesa_id)
         with mock.patch.object(payment_order, 'mode', False, create=True):
-            journal_odoo_id = self.po_obj._get_journal_odoo_id(
-                self.cursor, self.uid, payment_order
-            )
+            with self.assertRaises(Exception):
+                self.po_obj._get_journal_odoo_id(
+                    self.cursor, self.uid, payment_order
+                )
 
-        self.assertFalse(journal_odoo_id)
         mock_get_odoo_id_by_erp_id.assert_not_called()
 
     @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id")
@@ -276,7 +276,7 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
         mock_get_odoo_id_by_erp_id.assert_called_once()
 
     @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id")
-    def test__get_journal_odoo_id_returns_false_when_no_journal_matches_bank(
+    def test__get_journal_odoo_id_raises_when_no_journal_matches_bank(
             self, mock_get_odoo_id_by_erp_id):
         remesa_id = self.imd_obj.get_object_reference(
             self.cursor, self.uid, "som_sync_openerp", "remesa_0001"
@@ -284,11 +284,11 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
         payment_order = self.po_obj.browse(self.cursor, self.uid, remesa_id)
 
         with mock.patch.object(self.aj_obj, 'search', return_value=[]):
-            journal_odoo_id = self.po_obj._get_journal_odoo_id(
-                self.cursor, self.uid, payment_order
-            )
+            with self.assertRaises(Exception):
+                self.po_obj._get_journal_odoo_id(
+                    self.cursor, self.uid, payment_order
+                )
 
-        self.assertFalse(journal_odoo_id)
         mock_get_odoo_id_by_erp_id.assert_not_called()
 
     @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id")

--- a/som_sync_openerp/tests/tests_payment_order.py
+++ b/som_sync_openerp/tests/tests_payment_order.py
@@ -292,33 +292,6 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
         mock_get_odoo_id_by_erp_id.assert_not_called()
 
     @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id")
-    def test__get_journal_odoo_id_returns_false_when_multiple_journals_match_bank(
-            self, mock_get_odoo_id_by_erp_id):
-        remesa_id = self.imd_obj.get_object_reference(
-            self.cursor, self.uid, "som_sync_openerp", "remesa_0001"
-        )[1]
-        payment_order = self.po_obj.browse(self.cursor, self.uid, remesa_id)
-        self.aj_obj.create(self.cursor, self.uid, {
-            'name': 'Duplicate bank journal',
-            'code': 'DupBank',
-            'type': 'general',
-            'company_bank_id': payment_order.mode.bank_id.id,
-            'view_id': self.imd_obj.get_object_reference(
-                self.cursor, self.uid, 'account', 'account_journal_view'
-            )[1],
-            'sequence_id': self.imd_obj.get_object_reference(
-                self.cursor, self.uid, 'account', 'sequence_journal'
-            )[1],
-        })
-
-        journal_odoo_id = self.po_obj._get_journal_odoo_id(
-            self.cursor, self.uid, payment_order
-        )
-
-        self.assertFalse(journal_odoo_id)
-        mock_get_odoo_id_by_erp_id.assert_not_called()
-
-    @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id")
     @mock.patch.object(odoo_sync.OdooSync, "get_erp_id_by_odoo_id")
     @mock.patch.object(odoo_sync.OdooSync, "common_sync_model_create_update")
     def test__get_related_values_inbound(self, mock_syncronize_sync, mock_erp_id, mock_odoo_id):

--- a/som_sync_openerp/tests/tests_payment_order.py
+++ b/som_sync_openerp/tests/tests_payment_order.py
@@ -276,6 +276,22 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
         mock_get_odoo_id_by_erp_id.assert_called_once()
 
     @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id")
+    def test__get_journal_odoo_id_returns_false_when_no_journal_matches_bank(
+            self, mock_get_odoo_id_by_erp_id):
+        remesa_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, "som_sync_openerp", "remesa_0001"
+        )[1]
+        payment_order = self.po_obj.browse(self.cursor, self.uid, remesa_id)
+
+        with mock.patch.object(self.aj_obj, 'search', return_value=[]):
+            journal_odoo_id = self.po_obj._get_journal_odoo_id(
+                self.cursor, self.uid, payment_order
+            )
+
+        self.assertFalse(journal_odoo_id)
+        mock_get_odoo_id_by_erp_id.assert_not_called()
+
+    @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id")
     @mock.patch.object(odoo_sync.OdooSync, "get_erp_id_by_odoo_id")
     @mock.patch.object(odoo_sync.OdooSync, "common_sync_model_create_update")
     def test__get_related_values_inbound(self, mock_syncronize_sync, mock_erp_id, mock_odoo_id):

--- a/som_sync_openerp/views/account_journal_view.xml
+++ b/som_sync_openerp/views/account_journal_view.xml
@@ -8,8 +8,8 @@
                 <xpath expr="//field[@name='type']" position="after">
                     <field name="som_sync_odoo_account_moves"/>
                     <field name="som_sync_odoo_invoices"/>
-                    <field name="som_sync_company_partner_id" invisible="1"/>
-                    <field name="som_sync_bank_id"/>
+                    <field name="company_partner_id" invisible="1"/>
+                    <field name="company_bank_id"/>
                 </xpath>
             </field>
         </record>

--- a/som_sync_openerp/views/account_journal_view.xml
+++ b/som_sync_openerp/views/account_journal_view.xml
@@ -8,6 +8,7 @@
                 <xpath expr="//field[@name='type']" position="after">
                     <field name="som_sync_odoo_account_moves"/>
                     <field name="som_sync_odoo_invoices"/>
+                    <field name="som_sync_company_partner_id" invisible="1"/>
                     <field name="som_sync_bank_id"/>
                 </xpath>
             </field>
@@ -20,7 +21,6 @@
                 <xpath expr="//field[@name='type']" position="after">
                     <field name="som_sync_odoo_account_moves"/>
                     <field name="som_sync_odoo_invoices"/>
-                    <field name="som_sync_bank_id"/>
                 </xpath>
             </field>
         </record>

--- a/som_sync_openerp/views/account_journal_view.xml
+++ b/som_sync_openerp/views/account_journal_view.xml
@@ -8,6 +8,7 @@
                 <xpath expr="//field[@name='type']" position="after">
                     <field name="som_sync_odoo_account_moves"/>
                     <field name="som_sync_odoo_invoices"/>
+                    <field name="som_sync_bank_id"/>
                 </xpath>
             </field>
         </record>
@@ -19,6 +20,7 @@
                 <xpath expr="//field[@name='type']" position="after">
                     <field name="som_sync_odoo_account_moves"/>
                     <field name="som_sync_odoo_invoices"/>
+                    <field name="som_sync_bank_id"/>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
## Objectiu
Poder resoldre diari de banc per a remeses

## Targeta on es demana o Incidència
https://somenergia.openproject.com/wp/1708

## Comportament antic
Estava hardcoded l'id del diari de banc per a remeses

## Comportament nou
Es pot configurar un compte bancari al diaris, i en base a aquesta configuració i el compte bancari de mode de pagament de la remesa obtenim el diari.

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [x] Script de migració
- [ ] Modifica traduccions


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/som_sync_openerp_modules/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the hardcoded bank journal ID (`13`) in payment order sync with a configurable lookup: a new `company_bank_id` field on `account.journal` links a bank account to a journal, and `_get_journal_odoo_id` resolves the Odoo journal ID dynamically from the payment order's payment-mode bank. A SQL uniqueness constraint, migration, view update, and four new unit tests are included.

- `account.journal` gains a `company_bank_id` Many2one field (with domain filter via the related `company_partner_id`) and a `UNIQUE` constraint ensuring one bank → one journal.
- `_get_journal_odoo_id` now raises specific exceptions (`Exception` or `ForeingKeyNotAvailable`) for all three failure paths rather than returning a falsy value, so misconfiguration surfaces immediately instead of producing broken sync payloads.
- Existing integration tests (`test__get_related_values_inbound/outbound`, splitted variants) are updated to mock the newly-required `get_odoo_id_by_erp_id` call.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all three failure paths now raise exceptions, eliminating the previous risk of sending a falsy journal ID to Odoo, and the SQL uniqueness constraint ensures the bank-to-journal lookup is unambiguous.

The core change is well-contained: the hardcoded journal ID is replaced by a lookup that fails loudly rather than silently. The new field, constraint, migration, and tests all align correctly. No logic errors or data-integrity gaps were found in the changed code.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| som_sync_openerp/models/payment_order.py | Replaces hardcoded journal_odoo_id=13 with _get_journal_odoo_id(); all three error paths raise exceptions instead of returning False, which is a clear improvement over the previous behaviour. |
| som_sync_openerp/models/account_journal.py | Adds company_bank_id Many2one field with domain helper (company_partner_id) and a UNIQUE SQL constraint; clean and correct. |
| som_sync_openerp/migrations/5.0.25.5.0/post-0003_add_journal_bank_field.py | Calls _auto_init to create the new column (and UNIQUE constraint) and reloads the view XML; follows the established migration pattern for this module. |
| som_sync_openerp/tests/tests_payment_order.py | Adds four targeted tests for _get_journal_odoo_id (happy path, no mode, no journal match, no Odoo mapping) and correctly updates existing integration tests with the new get_odoo_id_by_erp_id mock. |
| som_sync_openerp/tests/tests_account_journal.py | New test file; single test verifies that creating a journal with a duplicate company_bank_id raises an exception (exercising the UNIQUE constraint). |
| som_sync_openerp/demo/odoo_sync_demo.xml | Assigns distinct bank accounts (res_partner_bank_0001, res_partner_bank_0002) to the two syncronizable journals in demo data, enabling existing integration tests to exercise the new lookup path. |
| som_sync_openerp/views/account_journal_view.xml | Adds company_partner_id (invisible) and company_bank_id fields to the journal form view; the domain reference is correct. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant PO as payment.order
    participant GJ as _get_journal_odoo_id
    participant AJ as account.journal (DB)
    participant OS as odoo.sync

    PO->>GJ: _build_splitted/normal_related_values(payment_order)
    GJ->>GJ: check payment_order.mode.bank_id
    alt mode or bank_id missing
        GJ-->>PO: raise Exception
    end
    GJ->>AJ: "search([('company_bank_id','=', bank_id)])"
    alt no journal found
        GJ-->>PO: raise Exception
    end
    GJ->>OS: get_odoo_id_by_erp_id('account.journal', journal_ids[0])
    alt no Odoo mapping
        GJ-->>PO: raise ForeingKeyNotAvailable
    end
    GJ-->>PO: return journal_odoo_id
    PO->>PO: build related values dict with destination_journal_id
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant PO as payment.order
    participant GJ as _get_journal_odoo_id
    participant AJ as account.journal (DB)
    participant OS as odoo.sync

    PO->>GJ: _build_splitted/normal_related_values(payment_order)
    GJ->>GJ: check payment_order.mode.bank_id
    alt mode or bank_id missing
        GJ-->>PO: raise Exception
    end
    GJ->>AJ: "search([('company_bank_id','=', bank_id)])"
    alt no journal found
        GJ-->>PO: raise Exception
    end
    GJ->>OS: get_odoo_id_by_erp_id('account.journal', journal_ids[0])
    alt no Odoo mapping
        GJ-->>PO: raise ForeingKeyNotAvailable
    end
    GJ-->>PO: return journal_odoo_id
    PO->>PO: build related values dict with destination_journal_id
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `som_sync_openerp/models/payment_order.py`, line 278-291 ([link](https://github.com/som-energia/som_sync_openerp_modules/blob/a45d28cff91621abc94283b5da131c7b41392ef5/som_sync_openerp/models/payment_order.py#L278-L291)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Sync proceeds with `False` journal ID when configuration is missing**

   `_build_splitted_related_values` (and `_build_normal_related_values` at line 305) place the return value of `_get_journal_odoo_id` directly into the sync payload without any early-return guard. When the method returns `False` (missing payment mode, unmatched bank, or no Odoo mapping), the dict sent to Odoo contains `'destination_journal_id': False`. Odoo will likely reject this with a validation error on a required field, causing the sync to fail on every payment order where the journal is misconfigured — silently blocking those orders rather than surfacing the problem at configuration time. Previously the hardcoded `13` always yielded a valid integer. Consider raising an exception or returning early in the build methods when `journal_odoo_id` is falsy.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["🦺 more restrictive when no destination ..."](https://github.com/som-energia/som_sync_openerp_modules/commit/373b08a5d654117b93a0275aba59bfceedcd6693) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37650890)</sub>

<!-- /greptile_comment -->