### PR TITLE
🐛 odoo sync error wrongly passed to synced instead of pending, when

### DIFF
--- a/som_sync_openerp/models/odoo_sync.py
+++ b/som_sync_openerp/models/odoo_sync.py
@@ -316,9 +316,11 @@ class OdooSync(osv.osv):
             ('model.model', '=', model),
             ('res_id', '=', openerp_id),
         ], limit=1)
+        sync_state_before_retry = False
         if sync_id:
-            state = sync_obj.read(cursor, uid, sync_id[0], ['sync_state'])['sync_state']
-            if state == 'pending':
+            sync_state_before_retry = sync_obj.read(
+                cursor, uid, sync_id[0], ['sync_state'])['sync_state']
+            if sync_state_before_retry == 'pending':
                 logger.info("Update Odoo state of record {} of model {}".format(openerp_id, model))
                 context['update_pending_state_sync'] = True
                 return self.common_update_pending_state(cursor, uid, sync_id[0], context=context)
@@ -413,7 +415,8 @@ class OdooSync(osv.osv):
                         'update_odoo_created_sync': True,
                     })
                 sync_state = 'synced' if odoo_id else 'error'
-                if odoo_id and not sync_id and hasattr(rp_obj, 'get_sync_state_on_creation'):
+                if odoo_id and hasattr(rp_obj, 'get_sync_state_on_creation') and (
+                        not sync_id or sync_state_before_retry == 'error'):
                     sync_state = rp_obj.get_sync_state_on_creation(
                         cursor, uid, openerp_id, context=context)
 

--- a/som_sync_openerp/tests/tests_odoo_sync.py
+++ b/som_sync_openerp/tests/tests_odoo_sync.py
@@ -719,6 +719,42 @@ class TestOdooSync(testing.OOTestCaseWithCursor):
     @mock.patch.object(odoo_sync.OdooSync, "create_odoo_record")
     @mock.patch.object(odoo_sync.OdooSync, "get_model_vals_to_sync")
     @mock.patch.object(odoo_sync.OdooSync, "sync_model_enabled_amplified")
+    def test__syncronize_sync__payment_order_retry_after_error_keeps_pending(
+            self, mock_sync_model_enabled_amplified, mock_get_model_vals_to_sync,
+            mock_create_odoo_record, mock_update_odoo_id, mock_get_sync_state):
+        payment_order_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, 'som_sync_openerp', 'remesa_0001'
+        )[1]
+        model_id = self.openerp.pool.get('ir.model').search(
+            self.cursor, self.uid, [('model', '=', 'payment.order')], limit=1
+        )[0]
+        self.sync_obj.create(self.cursor, self.uid, {
+            'model': model_id,
+            'res_id': payment_order_id,
+            'sync_state': 'error',
+        })
+        mock_sync_model_enabled_amplified.return_value = (True, True, False)
+        mock_get_model_vals_to_sync.return_value = {
+            'pnt_erp_id': payment_order_id,
+        }
+        mock_create_odoo_record.return_value = (4321, '')
+        mock_get_sync_state.return_value = 'pending'
+
+        odoo_id, erp_id = self.sync_obj.syncronize_sync(
+            self.cursor, self.uid, 'payment.order', 'sync', payment_order_id, context={}
+        )
+
+        self.assertEqual(odoo_id, 4321)
+        self.assertEqual(erp_id, payment_order_id)
+        mock_update_odoo_id.assert_called_once()
+        _, kwargs = mock_update_odoo_id.call_args
+        self.assertEqual(kwargs['context']['sync_state'], 'pending')
+
+    @mock.patch('som_sync_openerp.models.payment_order.PaymentOrder.get_sync_state_on_creation')
+    @mock.patch.object(odoo_sync.OdooSync, "update_odoo_id")
+    @mock.patch.object(odoo_sync.OdooSync, "create_odoo_record")
+    @mock.patch.object(odoo_sync.OdooSync, "get_model_vals_to_sync")
+    @mock.patch.object(odoo_sync.OdooSync, "sync_model_enabled_amplified")
     def test__syncronize_sync__payment_order_splitted_first_create_sets_synced(
             self, mock_sync_model_enabled_amplified, mock_get_model_vals_to_sync,
             mock_create_odoo_record, mock_update_odoo_id, mock_get_sync_state):


### PR DESCRIPTION
## Objectiu
🐛 odoo sync error wrongly passed to synced instead of pending, when Odoo is still processing it

## Targeta on es demana o Incidència


## Comportament antic


## Comportament nou


## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/som_sync_openerp_modules/pull/31?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a state-machine bug in `syncronize_sync`: when retrying a sync record that was in `error` state, the old guard (`not sync_id`) prevented `get_sync_state_on_creation` from being called, so the record was incorrectly transitioned to `synced` instead of letting the model decide (e.g., `pending` when Odoo is still processing).

- **`odoo_sync.py`**: Captures the pre-retry sync state in `sync_state_before_retry` and extends the condition to also invoke `get_sync_state_on_creation` when that prior state was `error`, in addition to the existing first-creation path.
- **`tests_odoo_sync.py`**: Adds `test__syncronize_sync__payment_order_retry_after_error_keeps_pending` which creates a real `odoo.sync` record in `error` state, runs `syncronize_sync`, and asserts the resulting `sync_state` propagated to `update_odoo_id` is `pending`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is targeted, the logic is correct, and the new test directly exercises the previously broken code path.

The change is a small, well-understood condition fix. The pre-retry state is correctly captured before the early-return branch so it's always available downstream. The two branches of the updated condition cover the intended cases without introducing gaps — records previously in synced state that somehow re-enter the creation path will still default to synced, which is the conservative choice. The accompanying test creates a real DB record in error state and verifies end-to-end that pending is propagated correctly.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_sync_openerp/models/odoo_sync.py | Fixes the condition that gates get_sync_state_on_creation: now also invokes it on error-state retries, not just first-time creations. Introduces sync_state_before_retry to carry the pre-retry state into the creation branch. |
| som_sync_openerp/tests/tests_odoo_sync.py | Adds a regression test covering the retry-from-error scenario: creates a sync record in 'error' state, triggers syncronize_sync, and asserts the resulting sync_state is 'pending' as returned by get_sync_state_on_creation. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[syncronize_sync called] --> B{sync_id exists?}
    B -- No --> C[sync_state_before_retry = False]
    B -- Yes --> D["Read sync_state → sync_state_before_retry"]
    D --> E{sync_state_before_retry == 'pending'?}
    E -- Yes --> F[return common_update_pending_state]
    E -- No --> G[Proceed with sync]
    C --> G
    G --> H{odoo_id found in Odoo?}
    H -- Yes --> I[Update existing record path]
    H -- No --> J[create_odoo_record]
    J --> K{odoo_id created?}
    K -- No --> L[sync_state = 'error']
    K -- Yes --> M{hasattr get_sync_state_on_creation AND not sync_id OR sync_state_before_retry == 'error'?}
    M -- Yes --> N["sync_state = get_sync_state_on_creation()"]
    M -- No --> O["sync_state = 'synced' (default)"]
    N --> P[update_odoo_id with sync_state in context]
    O --> P
    L --> P
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[syncronize_sync called] --> B{sync_id exists?}
    B -- No --> C[sync_state_before_retry = False]
    B -- Yes --> D["Read sync_state → sync_state_before_retry"]
    D --> E{sync_state_before_retry == 'pending'?}
    E -- Yes --> F[return common_update_pending_state]
    E -- No --> G[Proceed with sync]
    C --> G
    G --> H{odoo_id found in Odoo?}
    H -- Yes --> I[Update existing record path]
    H -- No --> J[create_odoo_record]
    J --> K{odoo_id created?}
    K -- No --> L[sync_state = 'error']
    K -- Yes --> M{hasattr get_sync_state_on_creation AND not sync_id OR sync_state_before_retry == 'error'?}
    M -- Yes --> N["sync_state = get_sync_state_on_creation()"]
    M -- No --> O["sync_state = 'synced' (default)"]
    N --> P[update_odoo_id with sync_state in context]
    O --> P
    L --> P
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["🐛 odoo sync error wrongly passed to syn..."](https://github.com/som-energia/som_sync_openerp_modules/commit/9d381b743cf56a24c83691683819fb4a0cbb00e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38362104)</sub>

<!-- /greptile_comment -->