### PR TITLE
Save fraccionaments line odoo ids

### DIFF
--- a/som_sync_openerp/models/account_invoice_fraccionament.py
+++ b/som_sync_openerp/models/account_invoice_fraccionament.py
@@ -1,4 +1,6 @@
 #  -*- coding: utf-8 -*-
+import json
+
 from osv import osv
 
 
@@ -100,6 +102,28 @@ class AccountInvoiceFraccionament(osv.osv):
             'lines': lines,
         }
         return res
+
+    def hook_after_odoo_creation(self, cr, uid, response, sync_vals):
+        if not response:
+            return
+        if not isinstance(response, dict):
+            response = json.loads(response)
+
+        metadata = response.get('data', {}).get('metadata', [])
+        if not metadata:
+            return
+
+        sync_obj = self.pool.get('odoo.sync')
+        for payment_metadata in metadata:
+            erp_id = payment_metadata.get('erp_id')
+            odoo_id = payment_metadata.get('odoo_id')
+            if not erp_id or not odoo_id:
+                continue
+            sync_obj.update_odoo_id(
+                cr, uid, 'account.invoice.fraccionament.fraccionaments',
+                erp_id, odoo_id,
+                context={'sync_state': 'synced', 'update_last_sync': True}
+            )
 
 
 AccountInvoiceFraccionament()

--- a/som_sync_openerp/models/payment_order.py
+++ b/som_sync_openerp/models/payment_order.py
@@ -250,13 +250,19 @@ class PaymentOrder(osv.osv):
                 'sync', fracc_id, context_copy)
 
         # now we can get the odoo_ids of the fraccionaments lines
+        fraccl_data_by_id = {
+            row['id']: row for row in aiff_obj.read(
+                cr, uid, fraccl_ids, ['import'], context=context)
+        }
         for fraccl_id in fraccl_ids:
-            payment_odoo_id = sync_obj.get_odoo_id_by_erp_id_from_odoo(
+            payment_odoo_id = sync_obj.get_odoo_id_by_erp_id(
                 cr, uid, 'account.invoice.fraccionament.fraccionaments', fraccl_id)
+            if not payment_odoo_id:
+                payment_odoo_id = sync_obj.get_odoo_id_by_erp_id_from_odoo(
+                    cr, uid, 'account.invoice.fraccionament.fraccionaments', fraccl_id)
             if payment_odoo_id:
                 payment_ids.append(payment_odoo_id)
-                fraccl_data = aiff_obj.read(cr, uid, fraccl_id, ['import'], context=context)
-                amount_total += fraccl_data['import']
+                amount_total += fraccl_data_by_id[fraccl_id]['import']
             else:
                 # if we don't find the odoo_id for a fraccionament line it means that the sync of
                 # the parent fraccionament has failed. This way we force error in the payment order

--- a/som_sync_openerp/tests/tests_account_invoice_fraccionament.py
+++ b/som_sync_openerp/tests/tests_account_invoice_fraccionament.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 from destral import testing
+import json
 import mock
 
 from ..models import odoo_sync
@@ -125,6 +126,54 @@ class TestAccountInvoiceFraccionament(testing.OOTestCaseWithCursor):
             ),
             'invoices/payments'
         )
+
+    def test__hook_after_odoo_creation_creates_sync_records_for_payment_lines(self):
+        response = {
+            'data': {
+                'metadata': [
+                    {'erp_id': 8001, 'odoo_id': 9001},
+                    {'erp_id': 8002, 'odoo_id': 9002},
+                ]
+            }
+        }
+
+        self.frac_obj.hook_after_odoo_creation(
+            self.cursor, self.uid, response, {'sync_state': 'synced'}
+        )
+
+        sync_ids = self.sync_obj.search(self.cursor, self.uid, [
+            ('model.model', '=', 'account.invoice.fraccionament.fraccionaments'),
+            ('res_id', 'in', [8001, 8002]),
+        ])
+        sync_data = self.sync_obj.read(
+            self.cursor, self.uid, sync_ids, ['res_id', 'odoo_id', 'sync_state']
+        )
+
+        self.assertEqual(len(sync_data), 2)
+        self.assertEqual(
+            sorted([(row['res_id'], row['odoo_id']) for row in sync_data]),
+            [(8001, 9001), (8002, 9002)]
+        )
+        self.assertEqual(set([row['sync_state'] for row in sync_data]), set(['synced']))
+
+    def test__hook_after_odoo_creation_accepts_string_response(self):
+        response = json.dumps({
+            'data': {
+                'metadata': [
+                    {'erp_id': 8101, 'odoo_id': 9101},
+                ]
+            }
+        })
+
+        self.frac_obj.hook_after_odoo_creation(
+            self.cursor, self.uid, response, {'sync_state': 'synced'}
+        )
+
+        sync_ids = self.sync_obj.search(self.cursor, self.uid, [
+            ('model.model', '=', 'account.invoice.fraccionament.fraccionaments'),
+            ('res_id', '=', 8101),
+        ])
+        self.assertTrue(sync_ids)
 
     @mock.patch.object(odoo_sync.OdooSync, 'get_odoo_id_by_erp_id')
     def test__get_endpoint_odoo_record_suffix(self, mock_get_odoo_id_by_erp_id):

--- a/som_sync_openerp/tests/tests_payment_order.py
+++ b/som_sync_openerp/tests/tests_payment_order.py
@@ -828,6 +828,44 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
 
     @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id_from_odoo")
     @mock.patch.object(odoo_sync.OdooSync, "common_sync_model_create_update")
+    def test__get_order_payment_lines_from_splitted_invoices_prefers_local_sync_ids(
+            self, mock_sync_create_update, mock_get_odoo_id_from_odoo):
+        remesa_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, "som_sync_openerp", "remesa_0001"
+        )[1]
+        model_id = self.openerp.pool.get('ir.model').search(
+            self.cursor, self.uid,
+            [('model', '=', 'account.invoice.fraccionament.fraccionaments')], limit=1
+        )[0]
+        mock_sync_create_update.return_value = (999, 1)
+
+        fraccl_id_1 = self.utils_create_fraccionament_in_order(remesa_id, import_amount=400.0)
+        fraccl_id_2 = self.utils_create_fraccionament_in_order(remesa_id, import_amount=100.0)
+
+        self.sync_obj.create(self.cursor, self.uid, {
+            'model': model_id,
+            'res_id': fraccl_id_1,
+            'odoo_id': 201,
+            'sync_state': 'synced',
+        })
+        self.sync_obj.create(self.cursor, self.uid, {
+            'model': model_id,
+            'res_id': fraccl_id_2,
+            'odoo_id': 202,
+            'sync_state': 'synced',
+        })
+
+        payment_order = self.po_obj.browse(self.cursor, self.uid, remesa_id)
+        payment_ids, amount = self.po_obj._get_order_payment_lines_from_splitted_invoices(
+            self.cursor, self.uid, payment_order
+        )
+
+        self.assertEqual(payment_ids, [201, 202])
+        self.assertEqual(amount, 500.0)
+        mock_get_odoo_id_from_odoo.assert_not_called()
+
+    @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id_from_odoo")
+    @mock.patch.object(odoo_sync.OdooSync, "common_sync_model_create_update")
     def test__get_order_payment_lines_from_splitted_invoices_syncs_fraccionament_parent(
             self, mock_sync_create_update, mock_get_odoo_id):
         """


### PR DESCRIPTION
## Objectiu


## Targeta on es demana o Incidència


## Comportament antic


## Comportament nou


## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/som_sync_openerp_modules/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR saves Odoo IDs for fraccionament lines after a successful sync by introducing a `hook_after_odoo_creation` callback on `AccountInvoiceFraccionament`, and makes the payment-order flow prefer locally-cached sync IDs before falling back to a remote Odoo API call.

- **`hook_after_odoo_creation`** parses `response['data']['metadata']` (accepting both dict and JSON string) and calls `update_odoo_id` for each `erp_id`/`odoo_id` pair returned by Odoo, persisting the line-level Odoo IDs in the local sync table.
- **`_get_order_payment_lines_from_splitted_invoices`** now batch-reads all fraccionament-line `import` amounts in a single call and consults the local `odoo.sync` table first (`get_odoo_id_by_erp_id`) before making an outbound API call, reducing network round-trips when IDs were already stored by the new hook.
- Tests cover both sync-record creation from the hook and the local-first lookup path in the payment-order flow.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The changes are well-scoped and behave correctly under normal inputs.

The new hook and local-first lookup work correctly. The two minor issues are a falsy guard on `odoo_id` that could silently skip a zero value (impossible in practice for Odoo IDs), and a test that asserts an ordered list whose order is not contractually guaranteed by the underlying search query.

The falsy guard in `account_invoice_fraccionament.py` and the ordered list assertion in `tests_payment_order.py` are the only spots worth a second look.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_sync_openerp/models/account_invoice_fraccionament.py | Adds `hook_after_odoo_creation` to parse API response metadata and persist Odoo IDs for fraccionament lines via `update_odoo_id`. Handles both dict and JSON-string responses. Minor: falsy guard on `odoo_id` could skip a valid `0` value. |
| som_sync_openerp/models/payment_order.py | Optimises the fraccionament-lines loop: batch-reads all `import` amounts upfront and checks the local sync DB first before making an Odoo API call. Clean, backward-compatible refactor. |
| som_sync_openerp/tests/tests_account_invoice_fraccionament.py | Adds two well-scoped unit tests for `hook_after_odoo_creation`: one verifying sync records are created with correct IDs/state, another verifying string-response deserialization. |
| som_sync_openerp/tests/tests_payment_order.py | Adds a test verifying local sync IDs are preferred over Odoo API calls. The ordered list assertion is slightly fragile as the underlying search has no explicit ORDER BY. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant AccountInvoiceFraccionament
    participant OdooAPI
    participant OdooSync
    participant PaymentOrder

    Note over Caller,OdooSync: Fraccionament sync (creates lines in Odoo)
    Caller->>AccountInvoiceFraccionament: common_sync_model_create_update(...)
    AccountInvoiceFraccionament->>OdooAPI: POST /api/v1/invoices/payments
    OdooAPI-->>AccountInvoiceFraccionament: "response {data: {metadata: [{erp_id, odoo_id}, ...]}}"
    AccountInvoiceFraccionament->>AccountInvoiceFraccionament: hook_after_odoo_creation(response, sync_vals)
    loop for each metadata entry
        AccountInvoiceFraccionament->>OdooSync: update_odoo_id(model, erp_id, odoo_id)
        OdooSync-->>AccountInvoiceFraccionament: sync record created/updated
    end

    Note over PaymentOrder,OdooAPI: Payment order building (local-first lookup)
    PaymentOrder->>OdooSync: get_odoo_id_by_erp_id(model, fraccl_id)
    alt ID found locally
        OdooSync-->>PaymentOrder: odoo_id
    else ID not cached
        PaymentOrder->>OdooAPI: "GET /entities/{model}/{erp_id}"
        OdooAPI-->>PaymentOrder: odoo_id
    end
    PaymentOrder->>PaymentOrder: append odoo_id, accumulate amount
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant AccountInvoiceFraccionament
    participant OdooAPI
    participant OdooSync
    participant PaymentOrder

    Note over Caller,OdooSync: Fraccionament sync (creates lines in Odoo)
    Caller->>AccountInvoiceFraccionament: common_sync_model_create_update(...)
    AccountInvoiceFraccionament->>OdooAPI: POST /api/v1/invoices/payments
    OdooAPI-->>AccountInvoiceFraccionament: "response {data: {metadata: [{erp_id, odoo_id}, ...]}}"
    AccountInvoiceFraccionament->>AccountInvoiceFraccionament: hook_after_odoo_creation(response, sync_vals)
    loop for each metadata entry
        AccountInvoiceFraccionament->>OdooSync: update_odoo_id(model, erp_id, odoo_id)
        OdooSync-->>AccountInvoiceFraccionament: sync record created/updated
    end

    Note over PaymentOrder,OdooAPI: Payment order building (local-first lookup)
    PaymentOrder->>OdooSync: get_odoo_id_by_erp_id(model, fraccl_id)
    alt ID found locally
        OdooSync-->>PaymentOrder: odoo_id
    else ID not cached
        PaymentOrder->>OdooAPI: "GET /entities/{model}/{erp_id}"
        OdooAPI-->>PaymentOrder: odoo_id
    end
    PaymentOrder->>PaymentOrder: append odoo_id, accumulate amount
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Save fraccionaments line odoo ids"](https://github.com/som-energia/som_sync_openerp_modules/commit/6a291afbdfc811a89f6b51c0987b7021ff872637) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38370062)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->