### PR TITLE
👔 add taxes

### DIFF
--- a/som_sync_openerp/migrations/account_tax.csv
+++ b/som_sync_openerp/migrations/account_tax.csv
@@ -40,3 +40,5 @@
 5087,348,"IGIC Exento Repercutido","Vendes"
 271,349,"Retencions IRPF 19%","Compres"
 257,362,"IVA 5% (béns)","Vendes"
+176, 109, "IVA 21% Intracomunitario. Bienes corrientes", "Compres"
+177, 112, "IVA 21% Intracomunitario. Bienes de inversión", "Compres"


### PR DESCRIPTION
## Objectiu


## Targeta on es demana o Incidència


## Comportament antic


## Comportament nou


## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/som_sync_openerp_modules/pull/35?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adjusts payment order syncing to handle small invoice rounding differences. The main changes are:

- Force invoice-linked payment line amounts to the invoice total when they differ by one currency rounding step.
- Add tests for the rounding adjustment and a larger partial-payment difference.
- Add two static account tax mappings for intracommunity 21% VAT taxes.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The payment amount override needs a fix before merging.

- A near-total partial payment can be rewritten to the full invoice total.
- The new tests cover a large partial-payment difference, but not the one-cent boundary that triggers the changed branch.
- The tax mapping additions look low risk in the changed migration format.

som_sync_openerp/models/payment_order.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_sync_openerp/models/payment_order.py | Adds a rounding correction for invoice-linked payment lines, but the amount comparison can also rewrite valid near-total partial payments. |
| som_sync_openerp/tests/tests_payment_order.py | Adds coverage for the new rounding behavior and a large partial amount, but misses the boundary partial-payment case. |
| som_sync_openerp/migrations/account_tax.csv | Adds two static account tax mappings; the numeric parsing path tolerates the added spacing. |

</details>

<sub>Reviews (1): Last reviewed commit: ["🐛 payment order lines round different t..."](https://github.com/som-energia/som_sync_openerp_modules/commit/e4e66dfa3c76acdfb23bf23080d5cc293f89acd3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40047223)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->