### PR TITLE
👔 Adaptar remeses de factures rectificatives a canvis de l'API

### DIFF
--- a/som_sync_openerp/models/payment_order.py
+++ b/som_sync_openerp/models/payment_order.py
@@ -169,15 +169,6 @@ class PaymentOrder(osv.osv):
         payment_line_vals['amount'] = abs(payment_line_vals['amount'])
         return payment_line_vals, [payment_line.ml_inv_ref.id] if payment_line.ml_inv_ref else None
 
-    def _get_order_line_from_batch_invoice(self, cr, uid, payment_line, context=None):
-        if context is None:
-            context = {}
-        payment_line_vals, erp_invoice_ids = self._get_order_lines_from_invoices(
-            cr, uid, payment_line, context=context)
-        invoice_id = payment_line_vals.pop('invoice_id', False)
-        payment_line_vals['invoice_ids'] = [invoice_id] if invoice_id else []
-        return payment_line_vals, erp_invoice_ids
-
     def _get_order_line_from_grouped_invoices(self, cr, uid, payment_line, context=None):
         """
          This method is used to get the values of the payment line to sync with Odoo
@@ -208,6 +199,13 @@ class PaymentOrder(osv.osv):
         payment_line_vals = {'amount': round(amount_total, 2)}
         payment_line_vals['invoice_ids'] = odoo_invoice_ids
         return payment_line_vals, erp_invoice_ids
+
+    def _convert_refund_lines_to_batch_lines(self, lines):
+        for line in lines:
+            invoice_id = line.pop('invoice_id', False)
+            if not invoice_id:
+                raise Exception('Refund batch line missing invoice_id')
+            line['invoice_ids'] = [invoice_id]
 
     def _get_order_payment_lines_from_splitted_invoices(self, cr, uid, payment_order, context=None):
         """
@@ -302,11 +300,10 @@ class PaymentOrder(osv.osv):
         pl_inv_ids = []
 
         is_batch = is_grouped or is_refund
+        discrepancy_is_grouped = is_grouped
 
         if is_grouped:
             function_to_get_lines = self._get_order_line_from_grouped_invoices
-        elif is_refund:
-            function_to_get_lines = self._get_order_line_from_batch_invoice
         else:
             function_to_get_lines = self._get_order_lines_from_invoices
 
@@ -324,7 +321,10 @@ class PaymentOrder(osv.osv):
             'Processing lines with discrepancies for payment order {}: lines: {}'.format(
                 payment_order.id, len(lines)))
         inv_obj.process_lines_with_discrepancies(
-            cr, uid, pl_inv_ids, lines, is_grouped=is_batch, context=context)
+            cr, uid, pl_inv_ids, lines, is_grouped=discrepancy_is_grouped, context=context)
+
+        if is_refund and not is_grouped:
+            self._convert_refund_lines_to_batch_lines(lines)
 
         po_total_amount = round(sum([line['amount'] for line in lines]), 2)
 

--- a/som_sync_openerp/models/payment_order.py
+++ b/som_sync_openerp/models/payment_order.py
@@ -32,14 +32,10 @@ class PaymentOrder(osv.osv):
         if is_splitted:
             return 'payment_orders/payments'
 
-        mapping = {
-            # (is_grouped, is_refund): 'model_name'
-            (True, True): 'payment_order_batches_refunds',  # TODO: does not exists this endpoint!!
-            (True, False): 'payment_orders/batches',
-            (False, True): 'payment_order_refunds',
-            (False, False): 'payment_orders',
-        }
-        return mapping.get((is_grouped, is_refund))
+        if is_grouped or is_refund:
+            return 'payment_orders/batches'
+
+        return 'payment_orders'
 
     def get_sync_state_on_creation(self, cr, uid, id, context=None):
         endpoint = self.get_mapping_model_post(cr, uid, id, context=context)
@@ -69,24 +65,14 @@ class PaymentOrder(osv.osv):
     # TODO: ask Punt to unify field names in API
     # ----------------------------------
     def _get_journal_odoo_field_name(self, cr, uid, is_grouped, is_refund, context=None):
-        mapping = {
-            # (is_grouped, is_refund): 'model_name'
-            (True, True): 'journal_id',  # payment_order_batches_refunds
-            (True, False): 'destination_journal_id',  # payment_order_batches
-            (False, True): 'journal_id',  # payment_order_refunds
-            (False, False): 'destination_journal_id',  # payment_orders
-        }
-        return mapping.get((is_grouped, is_refund))
+        if is_grouped or is_refund:
+            return 'destination_journal_id'
+        return 'destination_journal_id'
 
     def _get_payment_method_odoo_field_name(self, cr, uid, is_grouped, is_refund, context=None):
-        mapping = {
-            # (is_grouped, is_refund): 'model_name'
-            (True, True): 'payment_method_line_id',  # payment_order_batches_refunds
-            (True, False): 'payment_method_line_id',  # payment_orders/batches
-            (False, True): 'method_id',  # payment_order_refunds
-            (False, False): 'payment_method_line_id',  # payment_orders
-        }
-        return mapping.get((is_grouped, is_refund))
+        if is_grouped or is_refund:
+            return 'payment_method_line_id'
+        return 'payment_method_line_id'
 
     def _get_journal_odoo_id(self, cr, uid, payment_order, context=None):
         if context is None:
@@ -182,6 +168,15 @@ class PaymentOrder(osv.osv):
             cr, uid, 'payment.line', payment_line.id, context=context)
         payment_line_vals['amount'] = abs(payment_line_vals['amount'])
         return payment_line_vals, [payment_line.ml_inv_ref.id] if payment_line.ml_inv_ref else None
+
+    def _get_order_line_from_batch_invoice(self, cr, uid, payment_line, context=None):
+        if context is None:
+            context = {}
+        payment_line_vals, erp_invoice_ids = self._get_order_lines_from_invoices(
+            cr, uid, payment_line, context=context)
+        invoice_id = payment_line_vals.pop('invoice_id', False)
+        payment_line_vals['invoice_ids'] = [invoice_id] if invoice_id else []
+        return payment_line_vals, erp_invoice_ids
 
     def _get_order_line_from_grouped_invoices(self, cr, uid, payment_line, context=None):
         """
@@ -306,8 +301,12 @@ class PaymentOrder(osv.osv):
         lines = []
         pl_inv_ids = []
 
+        is_batch = is_grouped or is_refund
+
         if is_grouped:
             function_to_get_lines = self._get_order_line_from_grouped_invoices
+        elif is_refund:
+            function_to_get_lines = self._get_order_line_from_batch_invoice
         else:
             function_to_get_lines = self._get_order_lines_from_invoices
 
@@ -325,14 +324,14 @@ class PaymentOrder(osv.osv):
             'Processing lines with discrepancies for payment order {}: lines: {}'.format(
                 payment_order.id, len(lines)))
         inv_obj.process_lines_with_discrepancies(
-            cr, uid, pl_inv_ids, lines, is_grouped=is_grouped, context=context)
+            cr, uid, pl_inv_ids, lines, is_grouped=is_batch, context=context)
 
         po_total_amount = round(sum([line['amount'] for line in lines]), 2)
 
         if payment_order.type == 'payable':
             metode_pagament_id = eval(conf_obj.get(cr, uid, 'odoo_provider_payment_method', 0))
             # all amounts to negative when payment_order_batch payable
-            if is_grouped:
+            if is_batch:
                 po_total_amount = -abs(po_total_amount)
                 for line in lines:
                     line['amount'] = -abs(line['amount'])

--- a/som_sync_openerp/tests/tests_payment_order.py
+++ b/som_sync_openerp/tests/tests_payment_order.py
@@ -412,6 +412,52 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
         }
         self.assertEqual(related_values, expected_values)
 
+    @mock.patch.object(odoo_sync.OdooSync, "search")
+    @mock.patch.object(odoo_sync.OdooSync, "read")
+    @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id")
+    @mock.patch.object(odoo_sync.OdooSync, "get_erp_id_by_odoo_id")
+    @mock.patch.object(odoo_sync.OdooSync, "common_sync_model_create_update")
+    def test__get_related_values_refund_with_discrepancy_keeps_non_grouped_formula(
+            self, mock_syncronize_sync, mock_erp_id, mock_get_odoo_id_by_erp_id,
+            mock_read, mock_search):
+        import json
+        invoice_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, "som_sync_openerp", "invoice_0003"
+        )[1]
+        remesa_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, "som_sync_openerp", "remesa_0001"
+        )[1]
+        odoo_invoice_id = 99
+        odoo_journal_id = 13
+
+        mock_syncronize_sync.return_value = (odoo_invoice_id, invoice_id)
+        mock_erp_id.return_value = invoice_id
+        mock_get_odoo_id_by_erp_id.return_value = odoo_journal_id
+        mock_search.return_value = [1]
+        mock_read.return_value = [{
+            'res_id': invoice_id,
+            'odoo_id': odoo_invoice_id,
+            'odoo_last_update_result': json.dumps({
+                'data': {
+                    'metadata': [{
+                        'pnt_amount_total_erp_difference': 5.0,
+                        'move_type': 'out_refund',
+                    }]
+                }
+            })
+        }]
+        self.utils_open_invoice_add_to_order_with_ml_inv_ref(invoice_id, remesa_id)
+
+        related_values = self.po_obj.get_related_values(
+            self.cursor, self.uid, remesa_id
+        )
+
+        self.assertEqual(related_values['amount'], 1005.0)
+        self.assertEqual(related_values['lines'], [{
+            'amount': 1005.0,
+            'invoice_ids': [odoo_invoice_id],
+        }])
+
     @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id")
     @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id_from_odoo")
     @mock.patch.object(odoo_sync.OdooSync, "common_sync_model_create_update")

--- a/som_sync_openerp/tests/tests_payment_order.py
+++ b/som_sync_openerp/tests/tests_payment_order.py
@@ -374,6 +374,45 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
         self.assertEqual(related_values, expected_values)
 
     @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id")
+    @mock.patch.object(odoo_sync.OdooSync, "get_erp_id_by_odoo_id")
+    @mock.patch.object(odoo_sync.OdooSync, "common_sync_model_create_update")
+    def test__get_related_values_refund_uses_batch_contract(
+            self, mock_syncronize_sync, mock_erp_id, mock_odoo_id):
+        invoice_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, "som_sync_openerp", "invoice_0003"
+        )[1]
+        remesa_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, "som_sync_openerp", "remesa_0001"
+        )[1]
+        odoo_invoice_id = 99
+        odoo_journal_id = 13
+        erp_invoice_id = 1
+
+        mock_syncronize_sync.return_value = (odoo_invoice_id, erp_invoice_id)
+        mock_erp_id.return_value = invoice_id
+        mock_odoo_id.return_value = odoo_journal_id
+        self.utils_open_invoice_add_to_order_with_ml_inv_ref(invoice_id, remesa_id)
+
+        related_values = self.po_obj.get_related_values(
+            self.cursor, self.uid, remesa_id
+        )
+
+        expected_values = {
+            'amount': 1000.0,
+            'batch_type': 'inbound',
+            'destination_journal_id': odoo_journal_id,
+            'lines': [
+                {
+                    'amount': 1000.0,
+                    'invoice_ids': [odoo_invoice_id],
+                }
+            ],
+            'payment_method_line_id': 373,
+            'name': u'RECT_Remesa 0001',
+        }
+        self.assertEqual(related_values, expected_values)
+
+    @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id")
     @mock.patch.object(odoo_sync.OdooSync, "get_odoo_id_by_erp_id_from_odoo")
     @mock.patch.object(odoo_sync.OdooSync, "common_sync_model_create_update")
     def test__get_related_values_splitted_returns_payment_ids_and_amount(
@@ -887,7 +926,7 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
         result = self.po_obj.get_mapping_model_post(self.cursor, self.uid, remesa_id)
         self.assertEqual(result, 'payment_orders/batches')
 
-    def test__get_mapping_model_post_returns_payment_order_refunds_when_refund(self):
+    def test__get_mapping_model_post_returns_payment_order_batches_when_refund(self):
         invoice_id = self.imd_obj.get_object_reference(
             self.cursor, self.uid, "som_sync_openerp", "invoice_0003"
         )[1]
@@ -898,7 +937,7 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
 
         result = self.po_obj.get_mapping_model_post(self.cursor, self.uid, remesa_id)
 
-        self.assertEqual(result, 'payment_order_refunds')
+        self.assertEqual(result, 'payment_orders/batches')
 
     def test__get_sync_state_on_creation_returns_pending_when_normal(self):
         invoice_id = self.imd_obj.get_object_reference(


### PR DESCRIPTION
## Objectiu
Adaptar remeses de factures rectificatives a canvis de contracte de l'API

## Targeta on es demana o Incidència
https://somenergia.openproject.com/wp/1708

## Comportament antic
Les remeses amb factures rectificatives feien servir l'endpoint **_payment_order_refunds_**

## Comportament nou
Ara fan servir l'endpoint **_payment_orders/batches_**

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/som_sync_openerp_modules/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adapts refund payment remittances to the batch payment order API.

- Refund orders now post to `payment_orders/batches`.
- Refund line payloads are converted from `invoice_id` to `invoice_ids`.
- Batch-style amount handling now also applies to refund orders.
- Tests cover the new refund batch payload and discrepancy behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_sync_openerp/models/payment_order.py | Refund remittances now use the batch endpoint and payload shape while keeping non-grouped refund discrepancy amounts on the expected formula. |
| som_sync_openerp/tests/tests_payment_order.py | Tests were added and updated for refund batch payloads and refund discrepancy amounts. |

</details>

<sub>Reviews (2): Last reviewed commit: ["🦺 avoid grouped discrepancy formula for..."](https://github.com/som-energia/som_sync_openerp_modules/commit/37f2719acc9d5744cdd26a72fbf23756541c51c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40058204)</sub>

<!-- /greptile_comment -->