### PR TITLE
✨ add manual sync state to show required manual action

### DIFF
--- a/som_sync_openerp/models/odoo_sync.py
+++ b/som_sync_openerp/models/odoo_sync.py
@@ -324,6 +324,12 @@ class OdooSync(osv.osv):
                 logger.info("Update Odoo state of record {} of model {}".format(openerp_id, model))
                 context['update_pending_state_sync'] = True
                 return self.common_update_pending_state(cursor, uid, sync_id[0], context=context)
+            if sync_state_before_retry == 'pending_manual_action':
+                logger.info(
+                    "Skipping sync for record {} of model {}. Manual action required".format(
+                        openerp_id, model)
+                )
+                return False
 
         erp_data = {}
         rp_obj = self.pool.get(model)

--- a/som_sync_openerp/models/odoo_sync.py
+++ b/som_sync_openerp/models/odoo_sync.py
@@ -909,6 +909,7 @@ class OdooSync(osv.osv):
             ('draft', 'Draft'),
             ('error', 'Error'),
             ('pending', 'Pending'),
+            ('pending_manual_action', 'Pending manual action'),
             ('static', 'Static'),
             ('synced', 'Synced'),
             ('synced_with_warning', 'Synced with warning'),

--- a/som_sync_openerp/tests/tests_odoo_sync.py
+++ b/som_sync_openerp/tests/tests_odoo_sync.py
@@ -839,6 +839,20 @@ class TestOdooSync(testing.OOTestCaseWithCursor):
 
         self.assertFalse(result)
 
+    def test_common_update_pending_state__pending_manual_action(self):
+        model_id = self.openerp.pool.get('ir.model').search(
+            self.cursor, self.uid, [('model', '=', 'payment.order')], limit=1
+        )[0]
+        sync_id = self.sync_obj.create(self.cursor, self.uid, {
+            'model': model_id,
+            'res_id': 123,
+            'sync_state': 'pending_manual_action',
+        })
+
+        result = self.sync_obj.common_update_pending_state(self.cursor, self.uid, sync_id)
+
+        self.assertFalse(result)
+
     def test_common_update_pending_state__no_update_pending_state_method(self):
         # Create a sync record for a model without update_pending_state method
         model_id = self.openerp.pool.get('ir.model').search(
@@ -853,6 +867,29 @@ class TestOdooSync(testing.OOTestCaseWithCursor):
         result = self.sync_obj.common_update_pending_state(self.cursor, self.uid, sync_id)
 
         self.assertFalse(result)
+
+    @mock.patch.object(odoo_sync.OdooSync, "common_update_pending_state")
+    def test__cron_update_pending_state__skips_pending_manual_action(
+            self, mock_common_update_pending_state):
+        model_id = self.openerp.pool.get('ir.model').search(
+            self.cursor, self.uid, [('model', '=', 'payment.order')], limit=1
+        )[0]
+        pending_sync_id = self.sync_obj.create(self.cursor, self.uid, {
+            'model': model_id,
+            'res_id': 123,
+            'sync_state': 'pending',
+        })
+        self.sync_obj.create(self.cursor, self.uid, {
+            'model': model_id,
+            'res_id': 456,
+            'sync_state': 'pending_manual_action',
+        })
+
+        self.sync_obj._cron_update_pending_state(self.cursor, self.uid)
+
+        mock_common_update_pending_state.assert_called_once_with(
+            self.cursor, self.uid, pending_sync_id, context={}
+        )
 
 
 class TestOdooUrlRecord(testing.OOTestCaseWithCursor):

--- a/som_sync_openerp/tests/tests_odoo_sync.py
+++ b/som_sync_openerp/tests/tests_odoo_sync.py
@@ -802,6 +802,32 @@ class TestOdooSync(testing.OOTestCaseWithCursor):
             self.cursor, self.uid, sync_id, context={'update_pending_state_sync': True}
         )
 
+    @mock.patch.object(odoo_sync.OdooSync, "update_odoo_id")
+    @mock.patch.object(odoo_sync.OdooSync, "common_update_pending_state")
+    @mock.patch.object(odoo_sync.OdooSync, "create_odoo_record")
+    @mock.patch.object(odoo_sync.OdooSync, "sync_model_enabled_amplified")
+    def test__syncronize_sync__pending_manual_action_skips_retry(
+            self, mock_sync_model_enabled_amplified, mock_create_odoo_record,
+            mock_common_update_pending_state, mock_update_odoo_id):
+        model_id = self.openerp.pool.get('ir.model').search(
+            self.cursor, self.uid, [('model', '=', 'payment.order')], limit=1
+        )[0]
+        self.sync_obj.create(self.cursor, self.uid, {
+            'model': model_id,
+            'res_id': 987654,
+            'sync_state': 'pending_manual_action',
+        })
+        mock_sync_model_enabled_amplified.return_value = (True, True, False)
+
+        result = self.sync_obj.syncronize_sync(
+            self.cursor, self.uid, 'payment.order', 'sync', 987654, context={}
+        )
+
+        self.assertFalse(result)
+        mock_common_update_pending_state.assert_not_called()
+        mock_create_odoo_record.assert_not_called()
+        mock_update_odoo_id.assert_not_called()
+
     @mock.patch('som_sync_openerp.models.payment_order.PaymentOrder.update_pending_state')
     def test_common_update_pending_state__calls_update_pending_state(
             self, mock_update_pending_state):


### PR DESCRIPTION
## Goal
Add a new synchronization state `Pending manual action` that is manually assigned and excluded from automatic retry logic.

## Instructions
- Keep the new state out of cron/retry behavior.
- Use a minimal implementation.

## Discoveries
- `pending` is behavior-coupled in `odoo.sync`: it is the only state processed by `syncronize_sync`, `common_update_pending_state`, and `_cron_update_pending_state`.
- Because that logic already matches only `pending`, the production change could stay minimal and rely on tests to lock the contract.
- Local module tests are currently blocked because PostgreSQL is not reachable on `localhost:5432` in this environment.

## Accomplished
- ✅ Added `pending_manual_action` to the `sync_state` selection in `som_sync_openerp/models/odoo_sync.py`.
- ✅ Added a test ensuring `common_update_pending_state()` returns `False` for `pending_manual_action`.
- ✅ Added a cron test ensuring `_cron_update_pending_state()` only processes `pending` and skips `pending_manual_action`.
- ✅ Attempted verification with `dodestral test_som_sync_openerp_pending_manual_action -m som_sync_openerp`, which failed due to missing PostgreSQL connectivity.

## Next Steps
- Start the local PostgreSQL stack and rerun `dodestral test_som_sync_openerp_pending_manual_action -m som_sync_openerp`.
- If needed, expose the new state in any manual operational workflow or docs used by support/admin users.

## Relevant Files
- som_sync_openerp/models/odoo_sync.py — defines sync states and pending-state processing.
- som_sync_openerp/tests/tests_odoo_sync.py — covers pending/manual-action behavior and cron processing., session_id=session-2026-06-29-pending-manual-action

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a manual sync state for records that need human action. The main changes are:

- New `pending_manual_action` value in the sync state selection.
- Early return in sync retry handling for records in the manual-action state.
- Tests for direct sync, pending-state update, and cron skip behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_sync_openerp/models/odoo_sync.py | Adds the manual-action sync state and skips automatic sync retry work when an existing record is in that state. |
| som_sync_openerp/tests/tests_odoo_sync.py | Adds tests covering manual-action records in direct sync, pending-state update, and cron processing. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix greptile review"](https://github.com/som-energia/som_sync_openerp_modules/commit/54273d7178ede49f1d62e7ecdbd8b7d51e803c08) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40478067)</sub>

<!-- /greptile_comment -->