### PR TITLE
Add manual sync state

### DIFF
--- a/som_sync_openerp/models/odoo_sync.py
+++ b/som_sync_openerp/models/odoo_sync.py
@@ -324,6 +324,12 @@ class OdooSync(osv.osv):
                 logger.info("Update Odoo state of record {} of model {}".format(openerp_id, model))
                 context['update_pending_state_sync'] = True
                 return self.common_update_pending_state(cursor, uid, sync_id[0], context=context)
+            if sync_state_before_retry == 'pending_manual_action':
+                logger.info(
+                    "Skipping sync for record {} of model {}. Manual action required".format(
+                        openerp_id, model)
+                )
+                return False
 
         erp_data = {}
         rp_obj = self.pool.get(model)

--- a/som_sync_openerp/models/odoo_sync.py
+++ b/som_sync_openerp/models/odoo_sync.py
@@ -909,6 +909,7 @@ class OdooSync(osv.osv):
             ('draft', 'Draft'),
             ('error', 'Error'),
             ('pending', 'Pending'),
+            ('pending_manual_action', 'Pending manual action'),
             ('static', 'Static'),
             ('synced', 'Synced'),
             ('synced_with_warning', 'Synced with warning'),

--- a/som_sync_openerp/models/odoo_sync.py
+++ b/som_sync_openerp/models/odoo_sync.py
@@ -324,7 +324,7 @@ class OdooSync(osv.osv):
                 logger.info("Update Odoo state of record {} of model {}".format(openerp_id, model))
                 context['update_pending_state_sync'] = True
                 return self.common_update_pending_state(cursor, uid, sync_id[0], context=context)
-            if sync_state_before_retry == 'pending_manual_action':
+            if sync_state_before_retry == 'pending_manual_act':
                 logger.info(
                     "Skipping sync for record {} of model {}. Manual action required".format(
                         openerp_id, model)
@@ -915,7 +915,7 @@ class OdooSync(osv.osv):
             ('draft', 'Draft'),
             ('error', 'Error'),
             ('pending', 'Pending'),
-            ('pending_manual_action', 'Pending manual action'),
+            ('pending_manual_act', 'Pending manual action'),
             ('static', 'Static'),
             ('synced', 'Synced'),
             ('synced_with_warning', 'Synced with warning'),

--- a/som_sync_openerp/tests/tests_odoo_sync.py
+++ b/som_sync_openerp/tests/tests_odoo_sync.py
@@ -839,6 +839,20 @@ class TestOdooSync(testing.OOTestCaseWithCursor):
 
         self.assertFalse(result)
 
+    def test_common_update_pending_state__pending_manual_action(self):
+        model_id = self.openerp.pool.get('ir.model').search(
+            self.cursor, self.uid, [('model', '=', 'payment.order')], limit=1
+        )[0]
+        sync_id = self.sync_obj.create(self.cursor, self.uid, {
+            'model': model_id,
+            'res_id': 123,
+            'sync_state': 'pending_manual_action',
+        })
+
+        result = self.sync_obj.common_update_pending_state(self.cursor, self.uid, sync_id)
+
+        self.assertFalse(result)
+
     def test_common_update_pending_state__no_update_pending_state_method(self):
         # Create a sync record for a model without update_pending_state method
         model_id = self.openerp.pool.get('ir.model').search(
@@ -853,6 +867,29 @@ class TestOdooSync(testing.OOTestCaseWithCursor):
         result = self.sync_obj.common_update_pending_state(self.cursor, self.uid, sync_id)
 
         self.assertFalse(result)
+
+    @mock.patch.object(odoo_sync.OdooSync, "common_update_pending_state")
+    def test__cron_update_pending_state__skips_pending_manual_action(
+            self, mock_common_update_pending_state):
+        model_id = self.openerp.pool.get('ir.model').search(
+            self.cursor, self.uid, [('model', '=', 'payment.order')], limit=1
+        )[0]
+        pending_sync_id = self.sync_obj.create(self.cursor, self.uid, {
+            'model': model_id,
+            'res_id': 123,
+            'sync_state': 'pending',
+        })
+        self.sync_obj.create(self.cursor, self.uid, {
+            'model': model_id,
+            'res_id': 456,
+            'sync_state': 'pending_manual_action',
+        })
+
+        self.sync_obj._cron_update_pending_state(self.cursor, self.uid)
+
+        mock_common_update_pending_state.assert_called_once_with(
+            self.cursor, self.uid, pending_sync_id, context={}
+        )
 
 
 class TestOdooUrlRecord(testing.OOTestCaseWithCursor):

--- a/som_sync_openerp/tests/tests_odoo_sync.py
+++ b/som_sync_openerp/tests/tests_odoo_sync.py
@@ -815,7 +815,7 @@ class TestOdooSync(testing.OOTestCaseWithCursor):
         self.sync_obj.create(self.cursor, self.uid, {
             'model': model_id,
             'res_id': 987654,
-            'sync_state': 'pending_manual_action',
+            'sync_state': 'pending_manual_act',
         })
         mock_sync_model_enabled_amplified.return_value = (True, True, False)
 
@@ -872,7 +872,7 @@ class TestOdooSync(testing.OOTestCaseWithCursor):
         sync_id = self.sync_obj.create(self.cursor, self.uid, {
             'model': model_id,
             'res_id': 123,
-            'sync_state': 'pending_manual_action',
+            'sync_state': 'pending_manual_act',
         })
 
         result = self.sync_obj.common_update_pending_state(self.cursor, self.uid, sync_id)
@@ -908,7 +908,7 @@ class TestOdooSync(testing.OOTestCaseWithCursor):
         self.sync_obj.create(self.cursor, self.uid, {
             'model': model_id,
             'res_id': 456,
-            'sync_state': 'pending_manual_action',
+            'sync_state': 'pending_manual_act',
         })
 
         self.sync_obj._cron_update_pending_state(self.cursor, self.uid)

--- a/som_sync_openerp/tests/tests_odoo_sync.py
+++ b/som_sync_openerp/tests/tests_odoo_sync.py
@@ -802,6 +802,32 @@ class TestOdooSync(testing.OOTestCaseWithCursor):
             self.cursor, self.uid, sync_id, context={'update_pending_state_sync': True}
         )
 
+    @mock.patch.object(odoo_sync.OdooSync, "update_odoo_id")
+    @mock.patch.object(odoo_sync.OdooSync, "common_update_pending_state")
+    @mock.patch.object(odoo_sync.OdooSync, "create_odoo_record")
+    @mock.patch.object(odoo_sync.OdooSync, "sync_model_enabled_amplified")
+    def test__syncronize_sync__pending_manual_action_skips_retry(
+            self, mock_sync_model_enabled_amplified, mock_create_odoo_record,
+            mock_common_update_pending_state, mock_update_odoo_id):
+        model_id = self.openerp.pool.get('ir.model').search(
+            self.cursor, self.uid, [('model', '=', 'payment.order')], limit=1
+        )[0]
+        self.sync_obj.create(self.cursor, self.uid, {
+            'model': model_id,
+            'res_id': 987654,
+            'sync_state': 'pending_manual_action',
+        })
+        mock_sync_model_enabled_amplified.return_value = (True, True, False)
+
+        result = self.sync_obj.syncronize_sync(
+            self.cursor, self.uid, 'payment.order', 'sync', 987654, context={}
+        )
+
+        self.assertFalse(result)
+        mock_common_update_pending_state.assert_not_called()
+        mock_create_odoo_record.assert_not_called()
+        mock_update_odoo_id.assert_not_called()
+
     @mock.patch('som_sync_openerp.models.payment_order.PaymentOrder.update_pending_state')
     def test_common_update_pending_state__calls_update_pending_state(
             self, mock_update_pending_state):


### PR DESCRIPTION
## Objectiu


## Targeta on es demana o Incidència


## Comportament antic


## Comportament nou


## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/som_sync_openerp_modules/pull/38?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a manual-action sync state for Odoo synchronization. The main changes are:

- New `pending_manual_act` value in the sync state selection.
- Early skip in `syncronize_sync` for records waiting on manual action.
- Tests for direct sync, pending-state updates, and cron behavior with the new state.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- Manual-action records are skipped before sync work starts.
- Existing pending-state and cron paths already limit processing to `pending` records.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_sync_openerp/models/odoo_sync.py | Adds the manual-action sync state and skips synchronization when a record is in that state. |
| som_sync_openerp/tests/tests_odoo_sync.py | Adds tests covering manual-action records in direct sync, pending-state update, and cron paths. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into ADD\_manual\_sync..."](https://github.com/som-energia/som_sync_openerp_modules/commit/869e0608469893b4edc5ac0be0e79adc9ddc390a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40490937)</sub>

<!-- /greptile_comment -->