### PR TITLE
Add manual sync state

### DIFF
--- a/som_sync_openerp/migrations/5.0.25.5.0/post-0004_add_manual_pending_state.py
+++ b/som_sync_openerp/migrations/5.0.25.5.0/post-0004_add_manual_pending_state.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+import logging
+import pooler
+
+from tools import config
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+    if config.updating_all:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+    logger.info("Creating pooler")
+    pool = pooler.get_pool(cursor.dbname)
+
+    logger.info("Creating new state manual pending in odoo.sync")
+    pool.get('odoo.sync')._auto_init(
+        cursor, context={'module': 'som_sync_openerp'}
+    )
+    logger.info("State created successfully")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_sync_openerp/models/odoo_sync.py
+++ b/som_sync_openerp/models/odoo_sync.py
@@ -324,6 +324,12 @@ class OdooSync(osv.osv):
                 logger.info("Update Odoo state of record {} of model {}".format(openerp_id, model))
                 context['update_pending_state_sync'] = True
                 return self.common_update_pending_state(cursor, uid, sync_id[0], context=context)
+            if sync_state_before_retry == 'pending_manual_action':
+                logger.info(
+                    "Skipping sync for record {} of model {}. Manual action required".format(
+                        openerp_id, model)
+                )
+                return False
 
         erp_data = {}
         rp_obj = self.pool.get(model)

--- a/som_sync_openerp/models/odoo_sync.py
+++ b/som_sync_openerp/models/odoo_sync.py
@@ -909,6 +909,7 @@ class OdooSync(osv.osv):
             ('draft', 'Draft'),
             ('error', 'Error'),
             ('pending', 'Pending'),
+            ('pending_manual_action', 'Pending manual action'),
             ('static', 'Static'),
             ('synced', 'Synced'),
             ('synced_with_warning', 'Synced with warning'),

--- a/som_sync_openerp/models/odoo_sync.py
+++ b/som_sync_openerp/models/odoo_sync.py
@@ -324,7 +324,7 @@ class OdooSync(osv.osv):
                 logger.info("Update Odoo state of record {} of model {}".format(openerp_id, model))
                 context['update_pending_state_sync'] = True
                 return self.common_update_pending_state(cursor, uid, sync_id[0], context=context)
-            if sync_state_before_retry == 'pending_manual_action':
+            if sync_state_before_retry == 'pending_manual_act':
                 logger.info(
                     "Skipping sync for record {} of model {}. Manual action required".format(
                         openerp_id, model)
@@ -915,7 +915,7 @@ class OdooSync(osv.osv):
             ('draft', 'Draft'),
             ('error', 'Error'),
             ('pending', 'Pending'),
-            ('pending_manual_action', 'Pending manual action'),
+            ('pending_manual_act', 'Pending manual action'),
             ('static', 'Static'),
             ('synced', 'Synced'),
             ('synced_with_warning', 'Synced with warning'),

--- a/som_sync_openerp/tests/tests_odoo_sync.py
+++ b/som_sync_openerp/tests/tests_odoo_sync.py
@@ -839,6 +839,20 @@ class TestOdooSync(testing.OOTestCaseWithCursor):
 
         self.assertFalse(result)
 
+    def test_common_update_pending_state__pending_manual_action(self):
+        model_id = self.openerp.pool.get('ir.model').search(
+            self.cursor, self.uid, [('model', '=', 'payment.order')], limit=1
+        )[0]
+        sync_id = self.sync_obj.create(self.cursor, self.uid, {
+            'model': model_id,
+            'res_id': 123,
+            'sync_state': 'pending_manual_action',
+        })
+
+        result = self.sync_obj.common_update_pending_state(self.cursor, self.uid, sync_id)
+
+        self.assertFalse(result)
+
     def test_common_update_pending_state__no_update_pending_state_method(self):
         # Create a sync record for a model without update_pending_state method
         model_id = self.openerp.pool.get('ir.model').search(
@@ -853,6 +867,29 @@ class TestOdooSync(testing.OOTestCaseWithCursor):
         result = self.sync_obj.common_update_pending_state(self.cursor, self.uid, sync_id)
 
         self.assertFalse(result)
+
+    @mock.patch.object(odoo_sync.OdooSync, "common_update_pending_state")
+    def test__cron_update_pending_state__skips_pending_manual_action(
+            self, mock_common_update_pending_state):
+        model_id = self.openerp.pool.get('ir.model').search(
+            self.cursor, self.uid, [('model', '=', 'payment.order')], limit=1
+        )[0]
+        pending_sync_id = self.sync_obj.create(self.cursor, self.uid, {
+            'model': model_id,
+            'res_id': 123,
+            'sync_state': 'pending',
+        })
+        self.sync_obj.create(self.cursor, self.uid, {
+            'model': model_id,
+            'res_id': 456,
+            'sync_state': 'pending_manual_action',
+        })
+
+        self.sync_obj._cron_update_pending_state(self.cursor, self.uid)
+
+        mock_common_update_pending_state.assert_called_once_with(
+            self.cursor, self.uid, pending_sync_id, context={}
+        )
 
 
 class TestOdooUrlRecord(testing.OOTestCaseWithCursor):

--- a/som_sync_openerp/tests/tests_odoo_sync.py
+++ b/som_sync_openerp/tests/tests_odoo_sync.py
@@ -815,7 +815,7 @@ class TestOdooSync(testing.OOTestCaseWithCursor):
         self.sync_obj.create(self.cursor, self.uid, {
             'model': model_id,
             'res_id': 987654,
-            'sync_state': 'pending_manual_action',
+            'sync_state': 'pending_manual_act',
         })
         mock_sync_model_enabled_amplified.return_value = (True, True, False)
 
@@ -872,7 +872,7 @@ class TestOdooSync(testing.OOTestCaseWithCursor):
         sync_id = self.sync_obj.create(self.cursor, self.uid, {
             'model': model_id,
             'res_id': 123,
-            'sync_state': 'pending_manual_action',
+            'sync_state': 'pending_manual_act',
         })
 
         result = self.sync_obj.common_update_pending_state(self.cursor, self.uid, sync_id)
@@ -908,7 +908,7 @@ class TestOdooSync(testing.OOTestCaseWithCursor):
         self.sync_obj.create(self.cursor, self.uid, {
             'model': model_id,
             'res_id': 456,
-            'sync_state': 'pending_manual_action',
+            'sync_state': 'pending_manual_act',
         })
 
         self.sync_obj._cron_update_pending_state(self.cursor, self.uid)

--- a/som_sync_openerp/tests/tests_odoo_sync.py
+++ b/som_sync_openerp/tests/tests_odoo_sync.py
@@ -802,6 +802,32 @@ class TestOdooSync(testing.OOTestCaseWithCursor):
             self.cursor, self.uid, sync_id, context={'update_pending_state_sync': True}
         )
 
+    @mock.patch.object(odoo_sync.OdooSync, "update_odoo_id")
+    @mock.patch.object(odoo_sync.OdooSync, "common_update_pending_state")
+    @mock.patch.object(odoo_sync.OdooSync, "create_odoo_record")
+    @mock.patch.object(odoo_sync.OdooSync, "sync_model_enabled_amplified")
+    def test__syncronize_sync__pending_manual_action_skips_retry(
+            self, mock_sync_model_enabled_amplified, mock_create_odoo_record,
+            mock_common_update_pending_state, mock_update_odoo_id):
+        model_id = self.openerp.pool.get('ir.model').search(
+            self.cursor, self.uid, [('model', '=', 'payment.order')], limit=1
+        )[0]
+        self.sync_obj.create(self.cursor, self.uid, {
+            'model': model_id,
+            'res_id': 987654,
+            'sync_state': 'pending_manual_action',
+        })
+        mock_sync_model_enabled_amplified.return_value = (True, True, False)
+
+        result = self.sync_obj.syncronize_sync(
+            self.cursor, self.uid, 'payment.order', 'sync', 987654, context={}
+        )
+
+        self.assertFalse(result)
+        mock_common_update_pending_state.assert_not_called()
+        mock_create_odoo_record.assert_not_called()
+        mock_update_odoo_id.assert_not_called()
+
     @mock.patch('som_sync_openerp.models.payment_order.PaymentOrder.update_pending_state')
     def test_common_update_pending_state__calls_update_pending_state(
             self, mock_update_pending_state):


### PR DESCRIPTION
## Objectiu


## Targeta on es demana o Incidència


## Comportament antic


## Comportament nou


## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/som_sync_openerp_modules/pull/39?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a manual sync state for records that should not retry automatically. The main changes are:

- A new `pending_manual_act` value on `odoo.sync.sync_state`.
- A retry skip when a sync record is waiting for manual action.
- Tests for retry, pending-state update, and cron behavior.
- A migration hook for the updated `odoo.sync` model.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- The new state is consistently named across the model and tests.
- The retry, direct pending-state update, and cron paths all skip manual-action records.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_sync_openerp/models/odoo_sync.py | Adds the manual-action sync state and skips retry processing for records in that state. |
| som_sync_openerp/migrations/5.0.25.5.0/post-0004_add_manual_pending_state.py | Adds a post-migration hook that reinitializes the `odoo.sync` model using the same pattern as nearby migrations. |
| som_sync_openerp/tests/tests_odoo_sync.py | Adds coverage showing manual-action records are skipped by retry, pending-state update, and cron processing. |

</details>

<sub>Reviews (1): Last reviewed commit: ["🔨 migration script"](https://github.com/som-energia/som_sync_openerp_modules/commit/78509324b8412177ddc736132e01dd6c8c957891) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40491577)</sub>

<!-- /greptile_comment -->