### PR TITLE
✨ add payment order and invoice_id when is avaiable

### DIFF
--- a/scripts/export_account_move_lines_csv.py
+++ b/scripts/export_account_move_lines_csv.py
@@ -530,11 +530,16 @@ def lookup_invoice_id(client, invoice_value):
     invoice_value = to_text(invoice_value).strip()
     if not invoice_value:
         return u""
-    invoice_model = client.model("account.invoice")
-    for field_name in ["number", "reference", "move_name"]:
-        invoice_ids = invoice_model.search([(field_name, "=", invoice_value)])
-        if len(invoice_ids) == 1:
-            return to_text(invoice_ids[0])
+
+    try:
+        invoice_model = client.model("account.invoice")
+        for field_name in ["number", "reference", "move_name"]:
+            invoice_ids = invoice_model.search([(field_name, "=", invoice_value)])
+            if len(invoice_ids) == 1:
+                return to_text(invoice_ids[0])
+    except Exception:
+        return u""
+
     return u""
 
 

--- a/scripts/export_account_move_lines_csv.py
+++ b/scripts/export_account_move_lines_csv.py
@@ -21,6 +21,7 @@ except ImportError:
 
 import dbconfig
 from erppeek import Client
+from tqdm import tqdm
 
 
 def to_text(value):
@@ -126,7 +127,9 @@ class MoveInvoiceHintResolver(object):
             for txt in (to_text(ln.get("ref")), to_text(ln.get("name"))):
                 m = INVOICE_HINT_RE.search(txt or "")
                 if m:
-                    candidates[to_text(m.group(1)).upper()] = None
+                    key = to_text(m.group(1)).upper()
+                    if key not in candidates:
+                        candidates[key] = None
 
         value = list(candidates.items())[0] if len(candidates) == 1 else (None, None)
         self.cache[move_id] = value
@@ -334,25 +337,29 @@ class PaymentOrderResolver(object):
             self.order_cache[remesa_code] = (u"", u"")
             return self.order_cache[remesa_code]
 
-        order_model = self.client.model("payment.order")
-        order_ids = order_model.search([("reference", "=", remesa_code)])
-        if not order_ids:
-            order_ids = order_model.search([("name", "=", remesa_code)])
-
         order_name = u""
         order_id = u""
-        if len(order_ids) == 1:
-            order = order_model.read(order_ids[0], ["id", "name", "reference"])
-            order_name = to_text(order.get("name") or order.get("reference")).strip()
-            order_id = to_text(order.get("id"))
+        try:
+            order_model = self.client.model("payment.order")
+            order_ids = order_model.search([("reference", "=", remesa_code)])
+            if not order_ids:
+                order_ids = order_model.search([("name", "=", remesa_code)])
 
-        if not order_id:
-            remesa_model = self.client.model("giscedata.remesa.f1")
-            remesa_ids = remesa_model.search([("name", "=", remesa_code)])
-            if len(remesa_ids) == 1:
-                remesa = remesa_model.read(remesa_ids[0], ["id", "name"])
-                order_name = to_text(remesa.get("name") or remesa_code).strip()
-                order_id = to_text(remesa.get("id"))
+            if len(order_ids) == 1:
+                order = order_model.read(order_ids[0], ["id", "name", "reference"])
+                order_name = to_text(order.get("name") or order.get("reference")).strip()
+                order_id = to_text(order.get("id"))
+
+            if not order_id:
+                remesa_model = self.client.model("giscedata.remesa.f1")
+                remesa_ids = remesa_model.search([("name", "=", remesa_code)])
+                if len(remesa_ids) == 1:
+                    remesa = remesa_model.read(remesa_ids[0], ["id", "name"])
+                    order_name = to_text(remesa.get("name") or remesa_code).strip()
+                    order_id = to_text(remesa.get("id"))
+        except Exception:
+            order_name = u""
+            order_id = u""
 
         self.order_cache[remesa_code] = (order_name, order_id)
         return self.order_cache[remesa_code]
@@ -403,15 +410,18 @@ class DevolucioResolver(object):
             return self.cache[cache_key]
 
         amount = round(abs(float(signed_amount or 0.0)), 2)
-        devolucio_model = self.client.model("giscedata.facturacio.devolucio")
-        devolucio_ids = devolucio_model.search([("date", "=", line_date)])
-
         matches = []
-        for devolucio_id in devolucio_ids:
-            devolucio = devolucio_model.read(devolucio_id, ["id", "name", "linies_ids"])
-            total = self._get_devolucio_total(devolucio_id, devolucio.get("linies_ids") or [])
-            if total == amount:
-                matches.append((to_text(devolucio.get("name")).strip(), to_text(devolucio_id)))
+        try:
+            devolucio_model = self.client.model("giscedata.facturacio.devolucio")
+            devolucio_ids = devolucio_model.search([("date", "=", line_date)])
+
+            for devolucio_id in devolucio_ids:
+                devolucio = devolucio_model.read(devolucio_id, ["id", "name", "linies_ids"])
+                total = self._get_devolucio_total(devolucio_id, devolucio.get("linies_ids") or [])
+                if total == amount:
+                    matches.append((to_text(devolucio.get("name")).strip(), to_text(devolucio_id)))
+        except Exception:
+            matches = []
 
         value = matches[0] if len(matches) == 1 else (u"", u"")
         self.cache[cache_key] = value
@@ -541,11 +551,16 @@ def resolve_invoice_for_export(client, row, move_hint_resolver, remesa_resolver)
             if number:
                 return number, to_text(invoice_id or u"")
 
+    hinted_number = u""
     for candidate in (row.get("ref"), row.get("name")):
         m = INVOICE_HINT_RE.search(to_text(candidate) or u"")
         if m:
             number = to_text(m.group(1)).upper()
-            return number, lookup_invoice_id(client, number)
+            invoice_id = lookup_invoice_id(client, number)
+            if invoice_id:
+                return number, invoice_id
+            if not hinted_number:
+                hinted_number = number
 
     ref = to_text(row.get("ref")).strip()
     if ref:
@@ -556,6 +571,9 @@ def resolve_invoice_for_export(client, row, move_hint_resolver, remesa_resolver)
     number, invoice_id = move_hint_resolver.invoice_info_for_move(row.get("move_id"))
     if number:
         return number, to_text(invoice_id or lookup_invoice_id(client, number))
+
+    if hinted_number:
+        return hinted_number, u""
 
     if ref and re.search(r"\d", ref):
         return ref, lookup_invoice_id(client, ref)
@@ -612,7 +630,7 @@ def export_csv(account_code, date_from, date_to, output_path):
 
     with io.open(output_path, "w", encoding="utf-8", newline="") as fh:
         fh.write(u"id;data;compte_comptable;descripcio;nom_remesa;num_factura;res_id;import\n")
-        for row in rows:
+        for row in tqdm(rows, total=len(rows), desc="Exportant assentaments"):
             raw_name = to_text(row.get("name")).strip()
             signed = amount_signed(row.get("debit"), row.get("credit"))
             desc = classify_description(

--- a/scripts/export_account_move_lines_csv.py
+++ b/scripts/export_account_move_lines_csv.py
@@ -502,7 +502,7 @@ def classify_description(
         return u"[COMISSIÓ] Comissió"
 
     if u"devoluc" in lower_name:
-        return u"[DEVOLUCIONS] Devolucions"
+        return u"[REMESA] Devolucions"
 
     # Prioritat 4: pista de factura en altres línies del mateix assentament
     if move_hint_resolver:
@@ -586,18 +586,28 @@ def resolve_invoice_for_export(client, row, move_hint_resolver, remesa_resolver)
     return u"", u""
 
 
-def enrich_description(
-        desc, remesa_name=u"", devolucio_name=u"", invoice_number=u"", counterpart_label=u""):
+def normalize_description(desc, remesa_name=u"", devolucio_name=u"", invoice_number=u""):
     desc = to_text(desc).strip()
+    if desc.startswith(u"[FACTURA]") and invoice_number:
+        return u"[FACTURA] %s" % invoice_number
     if desc.startswith(u"[REMESA]") and remesa_name:
-        desc = u"[REMESA] %s" % remesa_name
-    elif desc.startswith(u"[DEVOLUCIONS]") and devolucio_name:
-        desc = u"[DEVOLUCIONS] %s" % devolucio_name
-    if invoice_number and invoice_number not in desc:
-        desc = u"%s %s" % (desc, invoice_number)
-    if counterpart_label and counterpart_label not in desc:
-        desc = u"%s [%s]" % (desc, counterpart_label)
+        return u"[REMESA] %s" % remesa_name
+    if desc.startswith(u"[REMESA]") and devolucio_name:
+        return u"[REMESA] %s" % devolucio_name
     return desc
+
+
+def build_description_extra(desc, invoice_number=u"", counterpart_label=u""):
+    parts = []
+    desc = to_text(desc).strip()
+    invoice_number = to_text(invoice_number).strip()
+    counterpart_label = to_text(counterpart_label).strip()
+
+    if invoice_number and not desc.startswith(u"[FACTURA] %s" % invoice_number):
+        parts.append(invoice_number)
+    if counterpart_label:
+        parts.append(counterpart_label)
+    return u" | ".join(parts)
 
 
 def export_csv(account_code, date_from, date_to, output_path):
@@ -634,7 +644,7 @@ def export_csv(account_code, date_from, date_to, output_path):
     unresolved_fake_remeses = set()
 
     with io.open(output_path, "w", encoding="utf-8", newline="") as fh:
-        fh.write(u"id;data;compte_comptable;descripcio;nom_remesa;num_factura;res_id;import\n")
+        fh.write(u"id;data;compte_comptable;descripcio;descripcio_extra;nom_remesa;num_factura;res_id;import\n")  # noqa:E501
         for row in tqdm(rows, total=len(rows), desc="Exportant assentaments"):
             raw_name = to_text(row.get("name")).strip()
             signed = amount_signed(row.get("debit"), row.get("credit"))
@@ -656,10 +666,14 @@ def export_csv(account_code, date_from, date_to, output_path):
                 client, row, move_hint_resolver, remesa_resolver
             )
             counterpart_label = counterpart_resolver.resolve_for_move(row.get("move_id"))
-            desc = enrich_description(
+            desc = normalize_description(
                 desc,
                 remesa_name=remesa_name,
                 devolucio_name=devolucio_name,
+                invoice_number=invoice_number,
+            )
+            description_extra = build_description_extra(
+                desc,
                 invoice_number=invoice_number,
                 counterpart_label=counterpart_label,
             )
@@ -672,11 +686,12 @@ def export_csv(account_code, date_from, date_to, output_path):
                 if REMESA_FAKE_RE.match(remesa_code) and desc.startswith(u"[REMESA]"):
                     unresolved_fake_remeses.add(remesa_code)
 
-            line = u"%s;%s;%s;%s;%s;%s;%s;%s\n" % (
+            line = u"%s;%s;%s;%s;%s;%s;%s;%s;%s\n" % (
                 to_text(row.get("id")),
                 to_text(row.get("date")),
                 account_code,
                 desc.replace(u";", u","),
+                description_extra.replace(u";", u","),
                 export_name.replace(u";", u","),
                 invoice_number.replace(u";", u","),
                 export_res_id.replace(u";", u","),

--- a/scripts/export_account_move_lines_csv.py
+++ b/scripts/export_account_move_lines_csv.py
@@ -32,6 +32,7 @@ def to_text(value):
 
 
 REMESA_FAKE_RE = re.compile(r"^\d{4}-\d{10,}$")
+PAYMENT_ORDER_RE = re.compile(r"^pagament\s+(\d{4}-\d{10,})$", re.IGNORECASE)
 INVOICE_HINT_RE = re.compile(r"\b(FPE\d+|RE/[^\s;]+|RG/[^\s;]+)\b", re.IGNORECASE)
 
 
@@ -58,10 +59,10 @@ class MoveInvoiceHintResolver(object):
         self.client = client
         self.cache = {}
 
-    def _invoice_number_from_any_model(self, invoice_id):
+    def _invoice_info_from_any_model(self, invoice_id):
         invoice_id = _extract_m2o_id(invoice_id)
         if not invoice_id:
-            return None
+            return None, None
 
         for model, fields in [
             ("giscedata.facturacio.factura", ["number", "name", "ref"]),
@@ -77,53 +78,62 @@ class MoveInvoiceHintResolver(object):
                     if val:
                         m = INVOICE_HINT_RE.search(val)
                         if m:
-                            return to_text(m.group(1)).upper()
-                        return val
+                            return to_text(m.group(1)).upper(), invoice_id
+                        return val, invoice_id
             except Exception:
                 continue
-        return None
+        return None, None
 
-    def invoice_hint_for_line(self, line):
+    def _invoice_number_from_any_model(self, invoice_id):
+        return self._invoice_info_from_any_model(invoice_id)[0]
+
+    def invoice_info_for_line(self, line):
         if not isinstance(line, dict):
-            return None
+            return None, None
         for field_name in ["invoice_id", "factura_id", "invoice", "factura"]:
             if field_name in line:
-                number = self._invoice_number_from_any_model(line.get(field_name))
+                number, invoice_id = self._invoice_info_from_any_model(line.get(field_name))
                 if number:
-                    return number
-        return None
+                    return number, invoice_id
+        return None, None
 
-    def invoice_hint_for_move(self, move_id):
+    def invoice_hint_for_line(self, line):
+        return self.invoice_info_for_line(line)[0]
+
+    def invoice_info_for_move(self, move_id):
         move_id = _extract_m2o_id(move_id)
         if not move_id:
-            return None
+            return None, None
         if move_id in self.cache:
             return self.cache[move_id]
 
         try:
             ids = self.client.AccountMoveLine.search([("move_id", "=", move_id)])
             if not ids:
-                self.cache[move_id] = None
-                return None
+                self.cache[move_id] = (None, None)
+                return None, None
             lines = self.client.AccountMoveLine.read(
                 ids, ["name", "ref", "invoice_id", "factura_id", "invoice", "factura"])
         except Exception:
-            self.cache[move_id] = None
-            return None
+            self.cache[move_id] = (None, None)
+            return None, None
 
-        candidates = set()
+        candidates = {}
         for ln in lines or []:
-            direct = self.invoice_hint_for_line(ln)
-            if direct:
-                candidates.add(direct)
+            direct_number, direct_id = self.invoice_info_for_line(ln)
+            if direct_number:
+                candidates[direct_number] = direct_id
             for txt in (to_text(ln.get("ref")), to_text(ln.get("name"))):
                 m = INVOICE_HINT_RE.search(txt or "")
                 if m:
-                    candidates.add(to_text(m.group(1)).upper())
+                    candidates[to_text(m.group(1)).upper()] = None
 
-        value = list(candidates)[0] if len(candidates) == 1 else None
+        value = list(candidates.items())[0] if len(candidates) == 1 else (None, None)
         self.cache[move_id] = value
         return value
+
+    def invoice_hint_for_move(self, move_id):
+        return self.invoice_info_for_move(move_id)[0]
 
 
 class RemesaFacturaResolver(object):
@@ -165,20 +175,23 @@ class RemesaFacturaResolver(object):
             return None
 
     def _invoice_number(self, invoice_id):
+        return self._invoice_info(invoice_id)[0]
+
+    def _invoice_info(self, invoice_id):
         if not invoice_id:
-            return None
+            return None, None
 
         number_candidates = ["number", "reference", "internal_number", "move_name"]
         usable = [f for f in number_candidates if f in self.invoice_fields] or ["number"]
         inv = self._read("account.invoice", invoice_id, usable)
         if not inv:
-            return None
+            return None, None
 
         for field_name in usable:
             value = to_text(inv.get(field_name)).strip()
             if value:
-                return value
-        return None
+                return value, invoice_id
+        return None, None
 
     def _find_remesa_ids(self, code):
         terms = [code, u"Remesa %s" % code]
@@ -208,18 +221,18 @@ class RemesaFacturaResolver(object):
             rel_fields = [f for f in ["invoice_id", "factura_id",
                                       "invoice", "factura"] if f in self.remesa_fields]
         if not rel_fields:
-            return None
+            return None, None
 
         remesa = self._read("giscedata.remesa.f1", remesa_id, rel_fields)
         if not remesa:
-            return None
+            return None, None
 
         for field_name in rel_fields:
             invoice_id = _extract_m2o_id(remesa.get(field_name))
             number = self._invoice_number(invoice_id)
             if number:
-                return number
-        return None
+                return number, invoice_id
+        return None, None
 
     def _invoice_from_related_lines(self, remesa_id):
         rel_fields = [
@@ -227,7 +240,7 @@ class RemesaFacturaResolver(object):
             if to_text(meta.get("type")) in ("one2many", "many2many")
         ]
 
-        candidates = set()
+        candidates = {}
         for field_name in rel_fields:
             meta = self.remesa_fields.get(field_name, {})
             relation_model = to_text(meta.get("relation"))
@@ -245,6 +258,9 @@ class RemesaFacturaResolver(object):
                 if to_text(m.get("type")) == "many2one"
                 and to_text(m.get("relation")) == "account.invoice"
             ]
+            if (relation_model == "giscedata.facturacio.factura"
+                    and "invoice_id" not in invoice_m2o_fields):
+                invoice_m2o_fields.append("invoice_id")
             for rel_id in rel_ids[:200]:
                 if invoice_m2o_fields:
                     rel_row = self._read(relation_model, rel_id, invoice_m2o_fields)
@@ -253,42 +269,191 @@ class RemesaFacturaResolver(object):
                             invoice_id = _extract_m2o_id(rel_row.get(m2o))
                             number = self._invoice_number(invoice_id)
                             if number:
-                                candidates.add(number)
+                                candidates[number] = invoice_id
 
                 for num_field in ["numfactura", "number", "invoice_number", "name"]:
                     if num_field in rel_meta:
                         rel_row = self._read(relation_model, rel_id, [num_field])
                         value = to_text((rel_row or {}).get(num_field)).strip()
                         if value and ("/" in value or value.upper().startswith("FPE")):
-                            candidates.add(value)
+                            candidates[value] = None
 
         if len(candidates) == 1:
-            return list(candidates)[0]
-        return None
+            return list(candidates.items())[0]
+        return None, None
 
-    def resolve_invoice_number(self, remesa_code):
+    def resolve_invoice(self, remesa_code):
         code = to_text(remesa_code).strip()
         if code in self.cache:
             return self.cache[code]
 
         if not code:
-            self.cache[code] = None
-            return None
+            self.cache[code] = (None, None)
+            return None, None
 
         remesa_ids = self._find_remesa_ids(code)
         for remesa_id in remesa_ids:
-            number = self._invoice_from_direct_rel(remesa_id)
+            number, invoice_id = self._invoice_from_direct_rel(remesa_id)
             if number:
-                self.cache[code] = number
-                return number
+                self.cache[code] = (number, invoice_id)
+                return number, invoice_id
 
-            number = self._invoice_from_related_lines(remesa_id)
+            number, invoice_id = self._invoice_from_related_lines(remesa_id)
             if number:
-                self.cache[code] = number
-                return number
+                self.cache[code] = (number, invoice_id)
+                return number, invoice_id
 
-        self.cache[code] = None
-        return None
+        self.cache[code] = (None, None)
+        return None, None
+
+    def resolve_invoice_number(self, remesa_code):
+        return self.resolve_invoice(remesa_code)[0]
+
+
+class PaymentOrderResolver(object):
+    def __init__(self, client):
+        self.client = client
+        self.cache = {}
+        self.order_cache = {}
+
+    def _extract_remesa_code(self, value):
+        txt = to_text(value).strip()
+        match = re.search(r"\bremesa\s+(.+)$", txt, re.IGNORECASE)
+        if match:
+            return to_text(match.group(1)).strip()
+        match = PAYMENT_ORDER_RE.match(txt)
+        if match:
+            return to_text(match.group(1)).strip()
+        return u""
+
+    def _resolve_order(self, remesa_code):
+        if remesa_code in self.order_cache:
+            return self.order_cache[remesa_code]
+
+        if not remesa_code:
+            self.order_cache[remesa_code] = (u"", u"")
+            return self.order_cache[remesa_code]
+
+        order_model = self.client.model("payment.order")
+        order_ids = order_model.search([("reference", "=", remesa_code)])
+        if not order_ids:
+            order_ids = order_model.search([("name", "=", remesa_code)])
+
+        order_name = u""
+        order_id = u""
+        if len(order_ids) == 1:
+            order = order_model.read(order_ids[0], ["id", "name", "reference"])
+            order_name = to_text(order.get("name") or order.get("reference")).strip()
+            order_id = to_text(order.get("id"))
+
+        if not order_id:
+            remesa_model = self.client.model("giscedata.remesa.f1")
+            remesa_ids = remesa_model.search([("name", "=", remesa_code)])
+            if len(remesa_ids) == 1:
+                remesa = remesa_model.read(remesa_ids[0], ["id", "name"])
+                order_name = to_text(remesa.get("name") or remesa_code).strip()
+                order_id = to_text(remesa.get("id"))
+
+        self.order_cache[remesa_code] = (order_name, order_id)
+        return self.order_cache[remesa_code]
+
+    def resolve_for_line(self, line_name, line_ref=u""):
+        cache_key = (to_text(line_name), to_text(line_ref))
+        if cache_key in self.cache:
+            return self.cache[cache_key]
+
+        remesa_code = self._extract_remesa_code(line_name) or self._extract_remesa_code(line_ref)
+        value = self._resolve_order(remesa_code)
+        self.cache[cache_key] = value
+        return value
+
+
+class DevolucioResolver(object):
+    def __init__(self, client):
+        self.client = client
+        self.cache = {}
+        self.lines_cache = {}
+
+    def _get_devolucio_total(self, devolucio_id, line_ids):
+        if devolucio_id in self.lines_cache:
+            return self.lines_cache[devolucio_id]
+
+        total = 0.0
+        if line_ids:
+            line_model = self.client.model("giscedata.facturacio.devolucio.linia")
+            rows = line_model.read(line_ids, ["import"])
+            if isinstance(rows, dict):
+                rows = [rows]
+            total = round(sum(float(row.get("import") or 0.0) for row in rows), 2)
+
+        self.lines_cache[devolucio_id] = total
+        return total
+
+    def resolve_for_line(self, line_name, line_date, signed_amount):
+        cache_key = (
+            to_text(line_name),
+            to_text(line_date),
+            round(abs(float(signed_amount or 0.0)), 2),
+        )
+        if cache_key in self.cache:
+            return self.cache[cache_key]
+
+        if u"devoluc" not in to_text(line_name).lower():
+            self.cache[cache_key] = (u"", u"")
+            return self.cache[cache_key]
+
+        amount = round(abs(float(signed_amount or 0.0)), 2)
+        devolucio_model = self.client.model("giscedata.facturacio.devolucio")
+        devolucio_ids = devolucio_model.search([("date", "=", line_date)])
+
+        matches = []
+        for devolucio_id in devolucio_ids:
+            devolucio = devolucio_model.read(devolucio_id, ["id", "name", "linies_ids"])
+            total = self._get_devolucio_total(devolucio_id, devolucio.get("linies_ids") or [])
+            if total == amount:
+                matches.append((to_text(devolucio.get("name")).strip(), to_text(devolucio_id)))
+
+        value = matches[0] if len(matches) == 1 else (u"", u"")
+        self.cache[cache_key] = value
+        return value
+
+
+class CounterpartAccountResolver(object):
+    def __init__(self, client, bank_account_ids):
+        self.client = client
+        self.bank_account_ids = set(bank_account_ids or [])
+        self.cache = {}
+
+    def resolve_for_move(self, move_id):
+        move_id = _extract_m2o_id(move_id)
+        if move_id in self.cache:
+            return self.cache[move_id]
+
+        if not move_id:
+            self.cache[move_id] = u""
+            return self.cache[move_id]
+
+        try:
+            line_ids = self.client.AccountMoveLine.search([("move_id", "=", move_id)])
+            lines = self.client.AccountMoveLine.read(line_ids, ["account_id"]) if line_ids else []
+        except Exception:
+            lines = []
+
+        counterparts = []
+        seen = set()
+        for line in lines or []:
+            account = line.get("account_id")
+            account_id = _extract_m2o_id(account)
+            if not account_id or account_id in self.bank_account_ids:
+                continue
+            label = to_text(account[1] if isinstance(account, (list, tuple))
+                            and len(account) > 1 else u"").strip()
+            if label and label not in seen:
+                seen.add(label)
+                counterparts.append(label)
+
+        self.cache[move_id] = u" | ".join(counterparts)
+        return self.cache[move_id]
 
 
 def classify_description(
@@ -319,6 +484,10 @@ def classify_description(
                 return u"[FACTURA] %s" % invoice_number
         return u"[REMESA] %s" % remesa_code
 
+    payment_order_match = PAYMENT_ORDER_RE.match(name)
+    if payment_order_match:
+        return u"[REMESA] %s" % payment_order_match.group(1).strip()
+
     if u"comissió" in lower_name or u"comissio" in lower_name or u"comisión" in lower_name:
         return u"[COMISSIÓ] Comissió"
 
@@ -347,6 +516,67 @@ def format_amount(value):
     return (u"%.2f" % value)
 
 
+def lookup_invoice_id(client, invoice_value):
+    invoice_value = to_text(invoice_value).strip()
+    if not invoice_value:
+        return u""
+    invoice_model = client.model("account.invoice")
+    for field_name in ["number", "reference", "move_name"]:
+        invoice_ids = invoice_model.search([(field_name, "=", invoice_value)])
+        if len(invoice_ids) == 1:
+            return to_text(invoice_ids[0])
+    return u""
+
+
+def resolve_invoice_for_export(client, row, move_hint_resolver, remesa_resolver):
+    number, invoice_id = move_hint_resolver.invoice_info_for_line(row)
+    if number:
+        return number, to_text(invoice_id or u"")
+
+    remesa_match = re.search(r"\bremesa\s+(.+)$", to_text(row.get("name")).strip(), re.IGNORECASE)
+    if remesa_match:
+        remesa_code = remesa_match.group(1).strip()
+        if REMESA_FAKE_RE.match(remesa_code):
+            number, invoice_id = remesa_resolver.resolve_invoice(remesa_code)
+            if number:
+                return number, to_text(invoice_id or u"")
+
+    for candidate in (row.get("ref"), row.get("name")):
+        m = INVOICE_HINT_RE.search(to_text(candidate) or u"")
+        if m:
+            number = to_text(m.group(1)).upper()
+            return number, lookup_invoice_id(client, number)
+
+    ref = to_text(row.get("ref")).strip()
+    if ref:
+        invoice_id = lookup_invoice_id(client, ref)
+        if invoice_id:
+            return ref, invoice_id
+
+    number, invoice_id = move_hint_resolver.invoice_info_for_move(row.get("move_id"))
+    if number:
+        return number, to_text(invoice_id or lookup_invoice_id(client, number))
+
+    if ref and re.search(r"\d", ref):
+        return ref, lookup_invoice_id(client, ref)
+
+    return u"", u""
+
+
+def enrich_description(
+        desc, remesa_name=u"", devolucio_name=u"", invoice_number=u"", counterpart_label=u""):
+    desc = to_text(desc).strip()
+    if desc.startswith(u"[REMESA]") and remesa_name:
+        desc = u"[REMESA] %s" % remesa_name
+    elif desc.startswith(u"[DEVOLUCIONS]") and devolucio_name:
+        desc = u"[DEVOLUCIONS] %s" % devolucio_name
+    if invoice_number and invoice_number not in desc:
+        desc = u"%s %s" % (desc, invoice_number)
+    if counterpart_label and counterpart_label not in desc:
+        desc = u"%s [%s]" % (desc, counterpart_label)
+    return desc
+
+
 def export_csv(account_code, date_from, date_to, output_path):
     client = Client(**dbconfig.erppeek)
 
@@ -365,7 +595,7 @@ def export_csv(account_code, date_from, date_to, output_path):
         print("No hi ha moviments per als filtres indicats.")
 
     line_fields = client.execute("account.move.line", "fields_get") or {}
-    wanted_fields = ["id", "date", "name", "ref", "move_id", "invoice_id",
+    wanted_fields = ["id", "date", "name", "ref", "move_id", "account_id", "invoice_id",
                      "factura_id", "invoice", "factura", "debit", "credit"]
     fields = [field for field in wanted_fields if field in line_fields]
     rows = client.AccountMoveLine.read(line_ids, fields) if line_ids else []
@@ -374,13 +604,17 @@ def export_csv(account_code, date_from, date_to, output_path):
     rows = sorted(rows, key=lambda r: (to_text(r.get("date")), int(r.get("id") or 0)))
     move_hint_resolver = MoveInvoiceHintResolver(client)
     remesa_resolver = RemesaFacturaResolver(client)
+    payment_order_resolver = PaymentOrderResolver(client)
+    devolucio_resolver = DevolucioResolver(client)
+    counterpart_resolver = CounterpartAccountResolver(client, account_ids)
 
     unresolved_fake_remeses = set()
 
     with io.open(output_path, "w", encoding="utf-8", newline="") as fh:
-        fh.write(u"id;data;compte_comptable;descripcio;import\n")
+        fh.write(u"id;data;compte_comptable;descripcio;nom_remesa;num_factura;res_id;import\n")
         for row in rows:
             raw_name = to_text(row.get("name")).strip()
+            signed = amount_signed(row.get("debit"), row.get("credit"))
             desc = classify_description(
                 row.get("name"),
                 row.get("ref"),
@@ -389,25 +623,47 @@ def export_csv(account_code, date_from, date_to, output_path):
                 move_hint_resolver,
                 remesa_resolver,
             )
+            remesa_name, remesa_id = payment_order_resolver.resolve_for_line(
+                row.get("name"), row.get("ref")
+            )
+            devolucio_name, devolucio_id = devolucio_resolver.resolve_for_line(
+                row.get("name"), row.get("date"), signed
+            )
+            invoice_number, invoice_id = resolve_invoice_for_export(
+                client, row, move_hint_resolver, remesa_resolver
+            )
+            counterpart_label = counterpart_resolver.resolve_for_move(row.get("move_id"))
+            desc = enrich_description(
+                desc,
+                remesa_name=remesa_name,
+                devolucio_name=devolucio_name,
+                invoice_number=invoice_number,
+                counterpart_label=counterpart_label,
+            )
+
+            export_name = remesa_name or devolucio_name
+            export_res_id = invoice_id or remesa_id or devolucio_id
             remesa_match = re.search(r"\bremesa\s+(.+)$", raw_name, re.IGNORECASE)
             if remesa_match:
                 remesa_code = remesa_match.group(1).strip()
                 if REMESA_FAKE_RE.match(remesa_code) and desc.startswith(u"[REMESA]"):
                     unresolved_fake_remeses.add(remesa_code)
 
-            signed = amount_signed(row.get("debit"), row.get("credit"))
-            line = u"%s;%s;%s;%s;%s\n" % (
+            line = u"%s;%s;%s;%s;%s;%s;%s;%s\n" % (
                 to_text(row.get("id")),
                 to_text(row.get("date")),
                 account_code,
                 desc.replace(u";", u","),
+                export_name.replace(u";", u","),
+                invoice_number.replace(u";", u","),
+                export_res_id.replace(u";", u","),
                 format_amount(signed),
             )
             fh.write(line)
 
-    print("CSV generat: %s (%s línies)" % (output_path, len(rows)))
+    print("CSV generat: %s (%s linies)" % (output_path, len(rows)))
     if unresolved_fake_remeses:
-        print("AVÍS: %s remeses fake sense factura trobada" % len(unresolved_fake_remeses))
+        print("AVIS: %s remeses fake sense factura trobada" % len(unresolved_fake_remeses))
         print("Exemples: %s" % ", ".join(sorted(unresolved_fake_remeses)[:10]))
 
 

--- a/som_sync_openerp/models/account_move.py
+++ b/som_sync_openerp/models/account_move.py
@@ -9,7 +9,7 @@ class AccountMove(osv.osv):
 
     MAPPING_FIELDS_TO_SYNC = {
         'id': 'pnt_erp_id',
-        'name': 'name',
+        'name': 'number',
         'journal_id': 'journal_id',
         'ref': 'ref',
         'date': 'date',


### PR DESCRIPTION
## Objectiu
✨ add payment order and invoice_id when is avaiable

## Targeta on es demana o Incidència


## Comportament antic


## Comportament nou


## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/som_sync_openerp_modules/pull/40?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR enriches the bank account move-lines CSV export by adding three new resolver classes (`PaymentOrderResolver`, `DevolucioResolver`, `CounterpartAccountResolver`), a new `resolve_invoice_for_export` helper, and a `tqdm` progress bar. The CSV output gains three new columns — `nom_remesa`, `num_factura`, and `res_id` — and the `MoveInvoiceHintResolver`/`RemesaFacturaResolver` classes are extended to return `(number, id)` tuples in addition to just numbers.

- **New resolvers** each wrap ORM access with try/except, cache by natural key, and return `(name, id)` tuples consistently.
- **`resolve_invoice_for_export`** consolidates multi-step invoice-ID resolution (direct M2O → remesa lookup → INVOICE_HINT_RE search → full-ref search → move fallback) into a single function called once per row.
- **`enrich_description`** post-processes the classified description by appending the resolved remesa name, invoice number, and counterpart account label.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after adding tqdm to requirements.txt; all new resolver logic is well-guarded with try/except and caching.

The new resolver classes consistently wrap ORM calls in try/except and use caches, and the previous review gaps have been addressed. The one concrete blocker is that tqdm is imported unconditionally at the module level but is absent from requirements.txt, meaning the script crashes with ImportError in any clean environment.

scripts/export_account_move_lines_csv.py — the unconditional tqdm import and missing requirements entry are the only items needing a fix.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/export_account_move_lines_csv.py | Substantial expansion of export logic: adds PaymentOrderResolver, DevolucioResolver, CounterpartAccountResolver, and resolve_invoice_for_export; enriches CSV with nom_remesa, num_factura, and res_id columns; tqdm import is missing from requirements.txt causing ImportError in clean environments. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[export_csv loop<br>for each row] --> B[classify_description]
    A --> C[PaymentOrderResolver]
    A --> D[DevolucioResolver]
    A --> E[resolve_invoice_for_export]
    A --> F[CounterpartAccountResolver]
    C --> C1[_resolve_order<br>payment.order or remesa.f1]
    D --> D1{devoluc in name?}
    D1 -->|Yes| D2[search devolucio by date]
    D2 --> D3[_get_devolucio_total]
    E --> E1[invoice_info_for_line]
    E --> E2[remesa_resolver.resolve_invoice]
    E --> E3[lookup_invoice_id<br>account.invoice search]
    E --> E4[invoice_info_for_move]
    B --> G[enrich_description]
    C --> G
    D --> G
    E --> G
    F --> G
    G --> H[CSV: id;data;compte;desc;<br>nom_remesa;num_factura;res_id;import]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[export_csv loop<br>for each row] --> B[classify_description]
    A --> C[PaymentOrderResolver]
    A --> D[DevolucioResolver]
    A --> E[resolve_invoice_for_export]
    A --> F[CounterpartAccountResolver]
    C --> C1[_resolve_order<br>payment.order or remesa.f1]
    D --> D1{devoluc in name?}
    D1 -->|Yes| D2[search devolucio by date]
    D2 --> D3[_get_devolucio_total]
    E --> E1[invoice_info_for_line]
    E --> E2[remesa_resolver.resolve_invoice]
    E --> E3[lookup_invoice_id<br>account.invoice search]
    E --> E4[invoice_info_for_move]
    B --> G[enrich_description]
    C --> G
    D --> G
    E --> G
    F --> G
    G --> H[CSV: id;data;compte;desc;<br>nom_remesa;num_factura;res_id;import]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["🦺 more improvements"](https://github.com/som-energia/som_sync_openerp_modules/commit/20a4860d16c478b99334db0f3696d6a36ea4948c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41306092)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->