### PR TITLE
✨ add script to get account balance at the end of the year

### DIFF
--- a/scripts/export_account_special_period_balances_csv.py
+++ b/scripts/export_account_special_period_balances_csv.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+"""
+Script per exportar saldos de comptes comptables des d'un període especial.
+
+   python scripts/export_account_special_period_balances_csv.py \
+     --account-prefix 572 \
+     --date 2025-12-31 \
+     --output /tmp/saldos_572_2025-12-31.csv
+"""
+from __future__ import print_function, unicode_literals
+
+import io
+import sys
+
+try:
+    import argparse
+except ImportError:
+    argparse = None
+
+import dbconfig
+from erppeek import Client
+from tqdm import tqdm
+
+
+def to_text(value):
+    if value is None:
+        return u""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", "replace")
+    return u"%s" % value
+
+
+def format_amount(value):
+    if value in (None, False, u"", ""):
+        return u""
+    return u"{0:.2f}".format(float(value))
+
+
+def get_accounts(client, account_code=None, account_prefix=None, account_pattern=None):
+    domain = []
+    if account_code:
+        domain = [("code", "=", account_code)]
+    elif account_prefix:
+        domain = [("code", "like", "%s%%" % account_prefix)]
+    else:
+        domain = [("code", "like", account_pattern)]
+
+    account_ids = client.AccountAccount.search(domain, order="code asc, id asc")
+    if not account_ids:
+        raise RuntimeError("No s'ha trobat cap compte pels filtres indicats")
+
+    return client.AccountAccount.read(account_ids, ["id", "code", "name"])
+
+
+def get_special_periods_for_date(client, target_date):
+    period_ids = client.AccountPeriod.search([
+        ("special", "=", True),
+        ("date_stop", "=", target_date),
+    ], order="code asc, id asc")
+
+    if not period_ids:
+        period_ids = client.AccountPeriod.search([
+            ("special", "=", True),
+            ("date_start", "=", target_date),
+        ], order="code asc, id asc")
+
+    if not period_ids:
+        return []
+
+    return client.AccountPeriod.read(period_ids, ["id", "code", "name", "date_start", "date_stop"])
+
+
+def build_period_map(periods):
+    period_map = {}
+    for period in periods:
+        period_map[int(period["id"])] = period
+    return period_map
+
+
+def get_balance_rows_for_account(client, account_id, period_ids):
+    if not period_ids:
+        return []
+
+    line_ids = client.AccountMoveLine.search([
+        ("account_id", "=", account_id),
+        ("period_id", "in", period_ids),
+    ], order="date asc, id asc")
+
+    if not line_ids:
+        return []
+
+    return client.AccountMoveLine.read(line_ids, ["debit", "credit", "period_id"])
+
+
+def compute_balance(lines):
+    balance = 0.0
+    for line in lines:
+        debit = float(line.get("debit") or 0.0)
+        credit = float(line.get("credit") or 0.0)
+        balance += debit - credit
+    return balance
+
+
+def get_used_period_codes(lines, period_map):
+    codes = []
+    used_ids = set()
+
+    for line in lines:
+        period_value = line.get("period_id")
+        if not isinstance(period_value, (list, tuple)) or not period_value:
+            continue
+        period_id = int(period_value[0])
+        if period_id in used_ids:
+            continue
+        used_ids.add(period_id)
+        period = period_map.get(period_id, {})
+        code = to_text(period.get("code") or period.get("name") or period_id)
+        codes.append(code)
+
+    return u",".join(codes)
+
+
+def export_csv(account_code, account_prefix, account_pattern, target_date, output_path):
+    client = Client(**dbconfig.erppeek)
+
+    accounts = get_accounts(
+        client,
+        account_code=account_code,
+        account_prefix=account_prefix,
+        account_pattern=account_pattern,
+    )
+    periods = get_special_periods_for_date(client, target_date)
+    period_ids = [int(period["id"]) for period in periods]
+    period_codes = u",".join([to_text(period.get("code") or period.get("name"))
+                             for period in periods])
+    period_map = build_period_map(periods)
+
+    with io.open(output_path, "w", encoding="utf-8", newline="") as fh:
+        fh.write(
+            u"account_code;account_name;date;special_period_found;special_period_codes;line_found;line_count;line_period_codes;balance\n"  # noqa: E501
+        )
+        for account in tqdm(accounts, total=len(accounts), desc="Exportant saldos"):
+            lines = get_balance_rows_for_account(client, account["id"], period_ids)
+            line_found = bool(lines)
+            balance = compute_balance(lines) if line_found else False
+            used_period_codes = get_used_period_codes(lines, period_map) if line_found else u""
+
+            row = u"%s;%s;%s;%s;%s;%s;%s;%s;%s\n" % (
+                to_text(account.get("code")),
+                to_text(account.get("name")).replace(u";", u","),
+                to_text(target_date),
+                to_text(bool(period_ids)),
+                period_codes.replace(u";", u","),
+                to_text(line_found),
+                to_text(len(lines)),
+                used_period_codes.replace(u";", u","),
+                format_amount(balance),
+            )
+            fh.write(row)
+
+    print("CSV generat: %s (%s comptes)" % (output_path, len(accounts)))
+    if not period_ids:
+        print("AVIS: no s'ha trobat cap període especial per a la data %s" % target_date)
+
+
+def parse_args(argv):
+    if argparse is None:
+        raise RuntimeError("argparse no disponible")
+
+    parser = argparse.ArgumentParser(
+        description="Exporta saldos de comptes comptables des d'un període especial"
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--account", help="Codi compte comptable exacte (ex: 572000000005)")
+    group.add_argument("--account-prefix", help="Prefix de compte comptable (ex: 572)")
+    group.add_argument("--account-pattern", help="Patró like d'OpenERP (ex: 572%)")
+    parser.add_argument("--date", required=True, help="Data del període especial (YYYY-MM-DD)")
+    parser.add_argument("--output", required=True, help="Ruta fitxer CSV de sortida")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv or sys.argv[1:])
+    export_csv(
+        args.account,
+        args.account_prefix,
+        args.account_pattern,
+        args.date,
+        args.output,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Goal
Implement a reusable CSV export script in som_sync_openerp_modules to extract account balances from special closing periods for accounts like 572.X.

## Instructions
- Build the script in the `som_sync_openerp_modules` repo, not in the ERP monorepo.
- If the special period or move line is not found, output `False` for manual checking.
- Output must be CSV.

## Discoveries
- `som_sync_openerp_modules/scripts/export_account_move_lines_csv.py` already establishes the preferred script pattern: `argparse` + `dbconfig` + `erppeek.Client`.
- The current environment does not have `erppeek` installed, so runtime verification could not go beyond syntax compilation.
- `requirements.txt` currently lists `odoo_rpc_client` only, even though existing scripts also import `erppeek`.

## Accomplished
- ✅ Added `scripts/export_account_special_period_balances_csv.py`.
- ✅ Implemented filters for exact account code, account prefix, or generic OpenERP `like` pattern.
- ✅ Implemented lookup of special periods by date and CSV export with one row per account.
- ✅ Added explicit `special_period_found` and `line_found` flags so missing data shows up as `False` for manual review.
- ✅ Verified Python syntax with `python3 -m py_compile`.
- ✅ Confirmed runtime help execution is currently blocked by missing `erppeek` in this environment.

## Next Steps
- Install or activate an environment with `erppeek` available.
- Run the script against the target ERP and inspect the generated CSV for 572 accounts on 2025-12-31.
- If needed, refine the special-period selection if accounting uses a narrower convention than all special periods on that date.

## Relevant Files
- som_sync_openerp_modules/scripts/export_account_special_period_balances_csv.py — new CSV exporter for balances from special periods.
- som_sync_openerp_modules/scripts/export_account_move_lines_csv.py — existing script used as implementation pattern.
- som_sync_openerp_modules/scripts/dbconfig.py — existing ERP connection config reused by the new script.
- som_sync_openerp_modules/requirements.txt — currently does not list `erppeek` even though scripts rely on it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/som_sync_openerp_modules/pull/41?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `scripts/export_account_special_period_balances_csv.py`, a new CSV export script that queries OpenERP for account balances in special closing periods (e.g. year-end periods for accounts matching a code, prefix, or `like` pattern). It follows the same `argparse` + `dbconfig` + `erppeek.Client` pattern as the existing `export_account_move_lines_csv.py`.

- **New script** looks up matching `account.account` records, finds special `account.period` entries for the target date (first by `date_stop`, then `date_start`), and writes one CSV row per account with balance, period codes, and explicit `special_period_found`/`line_found` flags.
- **`requirements.txt` is not updated**: both `erppeek` and `tqdm` are imported but unlisted, so the script will fail immediately after `pip install -r requirements.txt`.
- A minor defensive-coding gap exists in `get_accounts` where the `else` fallback silently passes `None` as the `like` value when all three filter arguments are `None`.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The script logic is correct and follows established patterns in the repo, but it cannot be run after a standard dependency install because `erppeek` and `tqdm` are missing from `requirements.txt`.

The core account-lookup and balance-aggregation logic is straightforward and well-structured. The main blocker is that both `erppeek` and `tqdm` are imported but absent from `requirements.txt`, so the script will fail at import time for anyone following the documented install path. This needs to be fixed before the script can be used reliably by other team members.

scripts/export_account_special_period_balances_csv.py and requirements.txt — the script works in isolation but the missing dependency declarations make it non-runnable out of the box.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/export_account_special_period_balances_csv.py | New script that exports account balances from special closing periods to CSV. Logic is sound but `erppeek` and `tqdm` are not listed in `requirements.txt`, making the script unrunnable after a fresh `pip install -r requirements.txt`. Contains a minor `account_pattern=None` fallthrough and a dead-code `argparse` import guard. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CLI as CLI (argparse)
    participant Script as export_csv()
    participant ERP as OpenERP (erppeek)
    participant CSV as Output CSV

    CLI->>Script: account_code/prefix/pattern, date, output_path
    Script->>ERP: AccountAccount.search(domain)
    ERP-->>Script: account_ids + records

    Script->>ERP: "AccountPeriod.search([special=True, date_stop=date])"
    alt periods found by date_stop
        ERP-->>Script: period records
    else no periods found
        Script->>ERP: "AccountPeriod.search([special=True, date_start=date])"
        ERP-->>Script: period records (or [])
    end

    Script->>CSV: write header row

    loop for each account
        Script->>ERP: AccountMoveLine.search([account_id, period_id in period_ids])
        ERP-->>Script: line records (debit, credit, period_id)
        Script->>Script: compute_balance(lines)
        Script->>Script: get_used_period_codes(lines, period_map)
        Script->>CSV: write row (special_period_found, line_found, balance)
    end

    Script->>CLI: print summary / warning if no periods found
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CLI as CLI (argparse)
    participant Script as export_csv()
    participant ERP as OpenERP (erppeek)
    participant CSV as Output CSV

    CLI->>Script: account_code/prefix/pattern, date, output_path
    Script->>ERP: AccountAccount.search(domain)
    ERP-->>Script: account_ids + records

    Script->>ERP: "AccountPeriod.search([special=True, date_stop=date])"
    alt periods found by date_stop
        ERP-->>Script: period records
    else no periods found
        Script->>ERP: "AccountPeriod.search([special=True, date_start=date])"
        ERP-->>Script: period records (or [])
    end

    Script->>CSV: write header row

    loop for each account
        Script->>ERP: AccountMoveLine.search([account_id, period_id in period_ids])
        ERP-->>Script: line records (debit, credit, period_id)
        Script->>Script: compute_balance(lines)
        Script->>Script: get_used_period_codes(lines, period_map)
        Script->>CSV: write row (special_period_found, line_found, balance)
    end

    Script->>CLI: print summary / warning if no periods found
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["✨ add script to get account balance at t..."](https://github.com/som-energia/som_sync_openerp_modules/commit/3b43833d756ad112a979676082eca6cae6514cdf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41605859)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->