### PR TITLE
👔 ref as name in account.move.lines

### DIFF
--- a/som_sync_openerp/models/account_move_line.py
+++ b/som_sync_openerp/models/account_move_line.py
@@ -9,7 +9,7 @@ class AccountMoveLine(osv.osv):
     MAPPING_FIELDS_TO_SYNC = {
         'account_id': 'account_id',
         'partner_id': 'partner_id',
-        'name': 'name',
+        'ref': 'name',
         'debit': 'debit',
         'credit': 'credit',
     }

--- a/som_sync_openerp/models/account_move_line.py
+++ b/som_sync_openerp/models/account_move_line.py
@@ -9,7 +9,8 @@ class AccountMoveLine(osv.osv):
     MAPPING_FIELDS_TO_SYNC = {
         'account_id': 'account_id',
         'partner_id': 'partner_id',
-        'ref': 'name',
+        'name': 'name',
+        'ref': 'ref',
         'debit': 'debit',
         'credit': 'credit',
     }
@@ -19,6 +20,13 @@ class AccountMoveLine(osv.osv):
     }
     MAPPING_CONSTANTS = {
     }
+
+    def hook_last_modifications(self, cr, uid, data, context=None):
+        if context is None:
+            context = {}
+        data['name'] = data.get('ref', False) or data.get('name', '')
+        data.pop('ref', False)
+        return data
 
 
 AccountMoveLine()

--- a/som_sync_openerp/tests/tests_account_move.py
+++ b/som_sync_openerp/tests/tests_account_move.py
@@ -10,6 +10,7 @@ class TestAccountMove(testing.OOTestCaseWithCursor):
 
     def setUp(self):
         self.am_obj = self.openerp.pool.get("account.move")
+        self.aml_obj = self.openerp.pool.get("account.move.line")
         self.imd_obj = self.openerp.pool.get("ir.model.data")
         self.sync_obj = self.openerp.pool.get("odoo.sync")
         super(TestAccountMove, self).setUp()
@@ -43,6 +44,24 @@ class TestAccountMove(testing.OOTestCaseWithCursor):
 
         }
         self.assertEqual(related_values, expected_values)
+
+    @mock.patch.object(odoo_sync.OdooSync, "common_sync_model_create_update")
+    def test__get_related_values_prioritizes_ref_over_name(self, mock_syncronize_sync):
+        move_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, "som_sync_openerp", "account_move_001"
+        )[1]
+        line_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, "som_sync_openerp", "account_move_line_001"
+        )[1]
+        mock_syncronize_sync.return_value = (99, 1)
+
+        self.aml_obj.write(self.cursor, self.uid, [line_id], {'ref': 'REF-001'})
+
+        related_values = self.am_obj.get_related_values(
+            self.cursor, self.uid, move_id
+        )
+
+        self.assertIn('REF-001', [line['name'] for line in related_values['lines']])
 
     def test__journal_is_syncrozable_True(self):
         move_id = self.imd_obj.get_object_reference(


### PR DESCRIPTION
## Objectiu


## Targeta on es demana o Incidència


## Comportament antic


## Comportament nou


## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/som_sync_openerp_modules/pull/42?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Review completed and submitted successfully.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge.

No blocking issues found.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["🐛 fallback to move line name when ref i..."](https://github.com/som-energia/som_sync_openerp_modules/commit/ce00dd69e27e2b93cad39f1b9143196347836fa1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41613656)</sub>

<!-- /greptile_comment -->