### PR TITLE
🦺 Norma57 improvements

### DIFF
--- a/som_sync_openerp/models/norma57_file.py
+++ b/som_sync_openerp/models/norma57_file.py
@@ -121,6 +121,9 @@ class Norma57File(osv.osv):
             lines.append(line_vals)
             invoice_ids.append(invoice_id)
 
+        if not lines:
+            raise Exception('Norma57 file has no syncable confirmed invoice lines')
+
         inv_obj.process_lines_with_discrepancies(
             cr, uid, invoice_ids, lines, is_grouped=False, context=context)
 

--- a/som_sync_openerp/tests/tests_norma57_file.py
+++ b/som_sync_openerp/tests/tests_norma57_file.py
@@ -119,6 +119,20 @@ class TestNorma57File(testing.OOTestCaseWithCursor):
                 with self.assertRaises(Exception):
                     self.n57_obj.get_related_values(self.cursor, self.uid, norma57_id)
 
+    def test_get_related_values_raises_when_no_confirmed_lines_are_syncable(self):
+        norma57_id = self._create_norma57_file()
+        self.conf_obj.set(self.cursor, self.uid, 'odoo_norma57_destination_journal', '17')
+        self.conf_obj.set(self.cursor, self.uid, 'odoo_norma57_payment_method', '411')
+
+        with mock.patch.object(self.n57_obj, 'browse') as mock_browse:
+            norma57_file = mock.Mock()
+            norma57_file.name = 'Norma57 test'
+            norma57_file.header_presentation_date = '2026-01-15'
+            norma57_file.lines = []
+            mock_browse.return_value = norma57_file
+            with self.assertRaises(Exception):
+                self.n57_obj.get_related_values(self.cursor, self.uid, norma57_id)
+
     @mock.patch.object(odoo_sync.OdooSync, 'common_sync_model_create_update')
     def test_confirm_triggers_norma57_sync(self, mock_sync):
         norma57_id = self._create_norma57_file()

--- a/som_sync_openerp/tests/tests_payment_order.py
+++ b/som_sync_openerp/tests/tests_payment_order.py
@@ -698,6 +698,7 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
         )
         mock_response = mock.Mock()
         mock_response.status_code = 200
+        mock_response.text = '{"error":"payment order failed"}'
         payment_order_id = self.imd_obj.get_object_reference(
             self.cursor, self.uid, 'som_sync_openerp', 'remesa_0001'
         )[1]


### PR DESCRIPTION
## Objectiu
Millores integració N57

## Targeta on es demana o Incidència
https://somenergia.openproject.com/wp/1708

## Comportament antic


## Comportament nou


## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/som_sync_openerp_modules/pull/44?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR tightens Norma57 sync handling and adjusts related tests. The main changes are:

- Raises when Norma57 payload generation has no syncable invoice lines.
- Adds test coverage for the empty Norma57 line case.
- Adds an error response body to a payment-order test mock.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_sync_openerp/models/norma57_file.py | Adds a defensive exception when Norma57 payload generation produces no syncable lines. |
| som_sync_openerp/tests/tests_norma57_file.py | Adds a direct unit test for the new empty-line exception path. |
| som_sync_openerp/tests/tests_payment_order.py | Updates a payment-order test mock with an error response body. |

</details>

<sub>Reviews (1): Last reviewed commit: ["🦺 Norma57 improvements"](https://github.com/som-energia/som_sync_openerp_modules/commit/3712b326f1f3e394bf609fdf6fc89e4d89a0bdce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42359713)</sub>

<!-- /greptile_comment -->