### PR TITLE
👔 Block account move sync for configured account prefixes

### DIFF
--- a/som_sync_openerp/models/account_move.py
+++ b/som_sync_openerp/models/account_move.py
@@ -7,6 +7,8 @@ class AccountMove(osv.osv):
     _name = 'account.move'
     _inherit = 'account.move'
 
+    SYNC_BLOCKED_ACCOUNT_PREFIXES = ('572',)
+
     MAPPING_FIELDS_TO_SYNC = {
         'id': 'pnt_erp_id',
         'name': 'number',
@@ -41,11 +43,23 @@ class AccountMove(osv.osv):
     def check_special_restrictions(self, cr, uid, id, context=None):
         if context is None:
             context = {}
-        return self._journal_is_syncrozable(cr, uid, id, context=context)
+        return self._journal_is_syncrozable(cr, uid, id, context=context) and not \
+            self._has_blocked_account_prefix(cr, uid, id, context=context)
 
     def _journal_is_syncrozable(self, cr, uid, _id, context=None):
         move = self.browse(cr, uid, _id, context=context)
         return move.journal_id and move.journal_id.som_sync_odoo_account_moves
+
+    def _has_blocked_account_prefix(self, cr, uid, _id, context=None):
+        if context is None:
+            context = {}
+        move = self.browse(cr, uid, _id, context=context)
+        for line in move.line_id:
+            account_code = line.account_id and line.account_id.code or ''
+            if any(account_code.startswith(prefix)
+                   for prefix in self.SYNC_BLOCKED_ACCOUNT_PREFIXES):
+                return True
+        return False
 
     def write(self, cr, uid, ids, vals, context=None):
         if context is None:

--- a/som_sync_openerp/tests/tests_account_move.py
+++ b/som_sync_openerp/tests/tests_account_move.py
@@ -11,6 +11,7 @@ class TestAccountMove(testing.OOTestCaseWithCursor):
     def setUp(self):
         self.am_obj = self.openerp.pool.get("account.move")
         self.aml_obj = self.openerp.pool.get("account.move.line")
+        self.account_obj = self.openerp.pool.get("account.account")
         self.imd_obj = self.openerp.pool.get("ir.model.data")
         self.sync_obj = self.openerp.pool.get("odoo.sync")
         super(TestAccountMove, self).setUp()
@@ -84,6 +85,34 @@ class TestAccountMove(testing.OOTestCaseWithCursor):
         )
 
         self.assertFalse(is_syncrozable)
+
+    def test__check_special_restrictions_returns_false_when_move_has_blocked_account_prefix(self):
+        blocked_line = mock.Mock()
+        blocked_line.account_id = mock.Mock(code='572000TEST')
+        move = mock.Mock()
+        move.journal_id = mock.Mock(som_sync_odoo_account_moves=True)
+        move.line_id = [blocked_line]
+
+        with mock.patch.object(self.am_obj, 'browse', return_value=move):
+            is_syncrozable = self.am_obj.check_special_restrictions(
+                self.cursor, self.uid, 1
+            )
+
+        self.assertFalse(is_syncrozable)
+
+    def test__check_special_restrictions_true_when_journal_syncable_and_no_blocked_prefix(self):
+        allowed_line = mock.Mock()
+        allowed_line.account_id = mock.Mock(code='430000TEST')
+        move = mock.Mock()
+        move.journal_id = mock.Mock(som_sync_odoo_account_moves=True)
+        move.line_id = [allowed_line]
+
+        with mock.patch.object(self.am_obj, 'browse', return_value=move):
+            is_syncrozable = self.am_obj.check_special_restrictions(
+                self.cursor, self.uid, 1
+            )
+
+        self.assertTrue(is_syncrozable)
 
     @mock.patch.object(odoo_sync.OdooSync, "syncronize_sync")
     @mock.patch.object(odoo_sync.OdooSync, "sync_model_enabled_amplified")


### PR DESCRIPTION
## Objectiu
Hem de controlar que no es sincronitzen assentaments amb apunts amb compte comptable de la 572..., si no es dupliquem amb els que venen de banc 

## Targeta on es demana o Incidència
https://somenergia.openproject.com/wp/1708

## Comportament antic
Es sincronitzaven tots

## Comportament nou
No es sincronitzen assentaments amb apunts amb compte comptable de la 572...

## Comprovacions

- [x] Hi ha testos
- [x] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/som_sync_openerp_modules/pull/45?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an account-move sync block for bank-account lines. The main changes are:

- Adds a blocked account prefix list for `account.move`.
- Skips account-move sync when any move line account starts with `572`.
- Adds tests for blocked and allowed account prefixes.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The changed flow looks mergeable after a small cleanup to make blocked prefixes configurable.

- The new move-level gate matches the stated `572` duplicate-prevention behavior.
- The prefix source is fixed in code, so other configured prefixes cannot be applied without a redeploy.
- The added tests cover the basic blocked and allowed prefix cases.

som_sync_openerp/models/account_move.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_sync_openerp/models/account_move.py | Adds the blocked-prefix gate for account-move sync; the prefix list is fixed in code. |
| som_sync_openerp/tests/tests_account_move.py | Adds unit tests for moves with blocked and allowed account prefixes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["👔 block account move sync for configure..."](https://github.com/som-energia/som_sync_openerp_modules/commit/6191d202e2ed8f98324bc07523f932cbfa54da73) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42662914)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->