### PR TITLE
✨ Normalize account codes with configurable target length

### DIFF
--- a/som_sync_openerp/data/som_sync_openerp_data.xml
+++ b/som_sync_openerp/data/som_sync_openerp_data.xml
@@ -153,6 +153,14 @@
                 Default ERP account.payment.term id used when an invoice has no payment term.
             </field>
         </record>
+        <record id="odoo_sync_account_code_normalized_length" model="res.config">
+            <field name="name">odoo_sync_account_code_normalized_length</field>
+            <field name="value">9</field>
+            <field name="description">
+                Target length used to normalize account.account codes for Odoo sync.
+                If empty, normalization is disabled.
+            </field>
+        </record>
         <record id="ir_cron_update_odoo_sync_pending_state" model="ir.cron">
             <field name="name">Actualitzar sincronitzacions pendents d'Odoo</field>
             <field name="active" eval="0"/>

--- a/som_sync_openerp/migrations/5.0.25.5.0/post-0006_update_account_code_normalization_config.py
+++ b/som_sync_openerp/migrations/5.0.25.5.0/post-0006_update_account_code_normalization_config.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+import logging
+import pooler
+
+from oopgrade.oopgrade import load_data
+from tools import config
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+    if config.updating_all:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+    logger.info('Creating pooler')
+    pooler.get_pool(cursor.dbname)
+
+    logger.info('Updating XML data for account code normalization config')
+    xmls = [
+        'data/som_sync_openerp_data.xml',
+    ]
+    for xml_path in xmls:
+        load_data(
+            cursor,
+            'som_sync_openerp',
+            xml_path,
+            idref=None,
+            mode='update'
+        )
+    logger.info('Account code normalization config XML data updated successfully')
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_sync_openerp/models/account_account.py
+++ b/som_sync_openerp/models/account_account.py
@@ -1,11 +1,20 @@
 #  -*- coding: utf-8 -*-
+import logging
+
 from osv import osv
 from service.security import Sudo
+
+
+logger = logging.getLogger(__name__)
 
 
 class AccountAccount(osv.osv):
     _name = 'account.account'
     _inherit = 'account.account'
+
+    ODOO_SYNC_NORMALIZED_LENGTH_KEY = 'odoo_sync_account_code_normalized_length'
+    ACCOUNT_CODE_PREFIX_LENGTH = 3
+    ACCOUNT_CODE_SUFFIX_LENGTH = 3
 
     MAPPING_FIELDS_TO_SYNC = {
         'name': 'name',
@@ -22,10 +31,99 @@ class AccountAccount(osv.osv):
             context = {}
         account = self.browse(cr, uid, id, context=context)
         if account.code:
-            res = '{}'.format(account.code)
+            res = '{}'.format(self._normalize_account_code_for_odoo(
+                cr, uid, account.code, context=context
+            ))
             return res
         else:
             return False
+
+    def _get_account_code_normalized_length(self, cr, uid, context=None):
+        if context is None:
+            context = {}
+        conf_obj = self.pool.get('res.config')
+        value = conf_obj.get(
+            cr, uid, self.ODOO_SYNC_NORMALIZED_LENGTH_KEY, ''
+        )
+        if value in (False, None, ''):
+            return False
+        try:
+            target_length = int(value)
+        except (TypeError, ValueError):
+            logger.warning(
+                'Invalid %s config value: %s',
+                self.ODOO_SYNC_NORMALIZED_LENGTH_KEY, value,
+            )
+            return False
+        if target_length <= 0:
+            logger.warning(
+                'Invalid %s config value: %s',
+                self.ODOO_SYNC_NORMALIZED_LENGTH_KEY, value,
+            )
+            return False
+        return target_length
+
+    def _normalize_account_code_for_odoo(self, cr, uid, code, context=None):
+        if context is None:
+            context = {}
+        if not code:
+            return code
+
+        target_length = self._get_account_code_normalized_length(
+            cr, uid, context=context
+        )
+        if not target_length:
+            return code
+
+        if not isinstance(code, basestring):
+            code = str(code)
+
+        if not code.isdigit() or len(code) <= target_length:
+            return code
+
+        prefix = code[:self.ACCOUNT_CODE_PREFIX_LENGTH]
+        suffix = code[-self.ACCOUNT_CODE_SUFFIX_LENGTH:]
+        middle = list(code[
+            self.ACCOUNT_CODE_PREFIX_LENGTH:-self.ACCOUNT_CODE_SUFFIX_LENGTH
+        ])
+
+        min_length = (
+            self.ACCOUNT_CODE_PREFIX_LENGTH + self.ACCOUNT_CODE_SUFFIX_LENGTH
+        )
+        if target_length < min_length:
+            logger.warning(
+                'Cannot normalize account code %s to target length %s: '
+                'target is shorter than preserved prefix/suffix length',
+                code, target_length,
+            )
+            return code
+
+        extra_chars = len(code) - target_length
+        zero_indexes = [index for index, char in enumerate(middle) if char == '0']
+        if len(zero_indexes) < extra_chars:
+            logger.warning(
+                'Cannot normalize account code %s to target length %s '
+                'without removing non-zero middle digits',
+                code, target_length,
+            )
+            return code
+
+        indexes_to_remove = set(zero_indexes[:extra_chars])
+        normalized_middle = ''.join([
+            char for index, char in enumerate(middle)
+            if index not in indexes_to_remove
+        ])
+        return '{}{}{}'.format(prefix, normalized_middle, suffix)
+
+    def hook_last_modifications(self, cr, uid, data, context=None):
+        if context is None:
+            context = {}
+        if 'code' not in data:
+            return data
+        data['code'] = self._normalize_account_code_for_odoo(
+            cr, uid, data.get('code'), context=context
+        )
+        return data
 
     def create(self, cr, uid, vals, context=None):
         if context is None:

--- a/som_sync_openerp/models/account_account.py
+++ b/som_sync_openerp/models/account_account.py
@@ -32,7 +32,7 @@ class AccountAccount(osv.osv):
         account = self.browse(cr, uid, id, context=context)
         if account.code:
             res = '{}'.format(self._normalize_account_code_for_odoo(
-                cr, uid, account.code, context=context
+                cr, uid, account.code, account_id=id, context=context
             ))
             return res
         else:
@@ -63,7 +63,21 @@ class AccountAccount(osv.osv):
             return False
         return target_length
 
-    def _normalize_account_code_for_odoo(self, cr, uid, code, context=None):
+    def _find_account_with_code(self, cr, uid, account_id, code, context=None):
+        if context is None:
+            context = {}
+        if not code:
+            return False
+
+        domain = [('code', '=', code)]
+        if account_id:
+            domain.append(('id', '!=', account_id))
+        account_ids = self.search(cr, uid, domain, limit=1, context=context)
+        if not account_ids:
+            return False
+        return self.browse(cr, uid, account_ids[0], context=context)
+
+    def _normalize_account_code_for_odoo(self, cr, uid, code, account_id=None, context=None):
         if context is None:
             context = {}
         if not code:
@@ -113,7 +127,17 @@ class AccountAccount(osv.osv):
             char for index, char in enumerate(middle)
             if index not in indexes_to_remove
         ])
-        return '{}{}{}'.format(prefix, normalized_middle, suffix)
+        normalized_code = '{}{}{}'.format(prefix, normalized_middle, suffix)
+        collision_account = self._find_account_with_code(
+            cr, uid, account_id, normalized_code, context=context
+        )
+        if collision_account:
+            logger.warning(
+                'Cannot normalize account code %s to %s because account %s already uses that code',
+                code, normalized_code, collision_account.id,
+            )
+            return code
+        return normalized_code
 
     def hook_last_modifications(self, cr, uid, data, context=None):
         if context is None:
@@ -121,7 +145,7 @@ class AccountAccount(osv.osv):
         if 'code' not in data:
             return data
         data['code'] = self._normalize_account_code_for_odoo(
-            cr, uid, data.get('code'), context=context
+            cr, uid, data.get('code'), account_id=data.get('pnt_erp_id'), context=context
         )
         return data
 

--- a/som_sync_openerp/tests/tests_account_account.py
+++ b/som_sync_openerp/tests/tests_account_account.py
@@ -116,6 +116,69 @@ class TestAccountAccount(testing.OOTestCaseWithCursor):
         self.assertEqual(vals['code'], '700000103')
 
     @mock.patch.object(odoo_sync.OdooSync, 'common_sync_model_create_update')
+    @mock.patch.object(account_account.logger, 'warning')
+    def test__normalize_account_code_for_odoo__keeps_original_when_normalized_code_exists(
+            self, mock_warning, mock_sync):
+        self.conf_obj.set(
+            self.cursor, self.uid,
+            'odoo_sync_account_code_normalized_length', '9'
+        )
+        account_type_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, 'som_sync_openerp', 'financieras'
+        )[1]
+        source_id = self.account_obj.create(self.cursor, self.uid, {
+            'name': 'Long ERP account',
+            'code': '700000000103',
+            'type': 'other',
+            'user_type': account_type_id,
+        })
+        self.account_obj.create(self.cursor, self.uid, {
+            'name': 'Existing normalized account',
+            'code': '700000103',
+            'type': 'other',
+            'user_type': account_type_id,
+        })
+
+        normalized = self.account_obj._normalize_account_code_for_odoo(
+            self.cursor, self.uid, '700000000103', account_id=source_id
+        )
+
+        self.assertEqual(normalized, '700000000103')
+        mock_warning.assert_called_once_with(
+            'Cannot normalize account code %s to %s because account %s already uses that code',
+            '700000000103', '700000103', mock.ANY,
+        )
+
+    @mock.patch.object(odoo_sync.OdooSync, 'common_sync_model_create_update')
+    def test__normalize_account_code_for_odoo__returns_normalized_when_no_existing_short_code(
+            self, mock_sync):
+        self.conf_obj.set(
+            self.cursor, self.uid,
+            'odoo_sync_account_code_normalized_length', '9'
+        )
+        account_type_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, 'som_sync_openerp', 'financieras'
+        )[1]
+        source_id = self.account_obj.create(self.cursor, self.uid, {
+            'name': 'Long ERP account',
+            'code': '700000000103',
+            'type': 'other',
+            'user_type': account_type_id,
+        })
+        self.account_obj.create(self.cursor, self.uid, {
+            'name': 'Different account',
+            'code': '701000103',
+            'type': 'other',
+            'user_type': account_type_id,
+        })
+
+        normalized = self.account_obj._normalize_account_code_for_odoo(
+            self.cursor, self.uid, '700000000103', account_id=source_id
+        )
+
+        self.assertEqual(normalized, '700000103')
+
+    @mock.patch.object(odoo_sync.OdooSync, 'common_sync_model_create_update')
     def test_ensure_demo_account_iva__reuses_existing_account(self, mock_sync):
         before_count = len(self.account_obj.search(
             self.cursor, self.uid, [('code', '=', '475600'), ('company_id', '=', 1)]

--- a/som_sync_openerp/tests/tests_account_account.py
+++ b/som_sync_openerp/tests/tests_account_account.py
@@ -1,11 +1,17 @@
 # -*- coding: utf-8 -*-
 from destral import testing
+import mock
+
+from ..models import account_account
+from ..models import odoo_sync
 
 
 class TestAccountAccount(testing.OOTestCaseWithCursor):
 
     def setUp(self):
         self.account_obj = self.openerp.pool.get("account.account")
+        self.conf_obj = self.openerp.pool.get("res.config")
+        self.sync_obj = self.openerp.pool.get("odoo.sync")
         self.imd_obj = self.openerp.pool.get("ir.model.data")
         super(TestAccountAccount, self).setUp()
 
@@ -18,7 +24,99 @@ class TestAccountAccount(testing.OOTestCaseWithCursor):
 
         self.assertEqual(suffix, '412345')
 
-    def test_ensure_demo_account_iva__reuses_existing_account(self):
+    def test__normalize_account_code_for_odoo__returns_original_when_config_empty(self):
+        self.conf_obj.set(
+            self.cursor, self.uid,
+            'odoo_sync_account_code_normalized_length', ''
+        )
+
+        normalized = self.account_obj._normalize_account_code_for_odoo(
+            self.cursor, self.uid, '700000000103'
+        )
+
+        self.assertEqual(normalized, '700000000103')
+
+    def test__normalize_account_code_for_odoo__reduces_middle_zeroes(self):
+        self.conf_obj.set(
+            self.cursor, self.uid,
+            'odoo_sync_account_code_normalized_length', '9'
+        )
+
+        normalized = self.account_obj._normalize_account_code_for_odoo(
+            self.cursor, self.uid, '700000000103'
+        )
+
+        self.assertEqual(normalized, '700000103')
+
+    def test__normalize_account_code_for_odoo__uses_configured_target_length(self):
+        self.conf_obj.set(
+            self.cursor, self.uid,
+            'odoo_sync_account_code_normalized_length', '8'
+        )
+
+        normalized = self.account_obj._normalize_account_code_for_odoo(
+            self.cursor, self.uid, '700000000103'
+        )
+
+        self.assertEqual(normalized, '70000103')
+
+    @mock.patch.object(account_account.logger, 'warning')
+    def test__normalize_account_code_for_odoo__warns_when_not_reducible(
+            self, mock_warning):
+        self.conf_obj.set(
+            self.cursor, self.uid,
+            'odoo_sync_account_code_normalized_length', '9'
+        )
+
+        normalized = self.account_obj._normalize_account_code_for_odoo(
+            self.cursor, self.uid, '700123456789'
+        )
+
+        self.assertEqual(normalized, '700123456789')
+        mock_warning.assert_called_once_with(
+            'Cannot normalize account code %s to target length %s '
+            'without removing non-zero middle digits',
+            '700123456789', 9,
+        )
+
+    def test__get_endpoint_suffix__returns_normalized_code_when_enabled(self):
+        self.conf_obj.set(
+            self.cursor, self.uid,
+            'odoo_sync_account_code_normalized_length', '9'
+        )
+        account_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, "account", "account_unpaid"
+        )[1]
+        self.account_obj.write(self.cursor, self.uid, [account_id], {
+            'code': '700000000103',
+        })
+
+        suffix = self.account_obj.get_endpoint_suffix(
+            self.cursor, self.uid, account_id
+        )
+
+        self.assertEqual(suffix, '700000103')
+
+    def test__get_model_vals_to_sync__normalizes_code_when_enabled(self):
+        self.conf_obj.set(
+            self.cursor, self.uid,
+            'odoo_sync_account_code_normalized_length', '9'
+        )
+        account_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, "account", "account_unpaid"
+        )[1]
+        self.account_obj.write(self.cursor, self.uid, [account_id], {
+            'code': '700000000103',
+        })
+
+        vals = self.sync_obj.get_model_vals_to_sync(
+            self.cursor, self.uid, 'account.account', account_id
+        )
+
+        self.assertEqual(vals['code'], '700000103')
+
+    @mock.patch.object(odoo_sync.OdooSync, 'common_sync_model_create_update')
+    def test_ensure_demo_account_iva__reuses_existing_account(self, mock_sync):
         before_count = len(self.account_obj.search(
             self.cursor, self.uid, [('code', '=', '475600'), ('company_id', '=', 1)]
         ))
@@ -34,7 +132,8 @@ class TestAccountAccount(testing.OOTestCaseWithCursor):
         self.assertTrue(ensured_id in account_ids)
         self.assertEqual(len(account_ids), before_count)
 
-    def test_ensure_demo_account_iva__creates_missing_account(self):
+    @mock.patch.object(odoo_sync.OdooSync, 'common_sync_model_create_update')
+    def test_ensure_demo_account_iva__creates_missing_account(self, mock_sync):
         account_id = self.imd_obj.get_object_reference(
             self.cursor, self.uid, 'som_sync_openerp', 'account_account_iva'
         )[1]
@@ -47,9 +146,15 @@ class TestAccountAccount(testing.OOTestCaseWithCursor):
         ensured_id = self.account_obj.ensure_demo_account_iva(
             self.cursor, self.uid, context={}
         )
-        xml_account_id = self.imd_obj.get_object_reference(
-            self.cursor, self.uid, 'som_sync_openerp', 'account_account_iva'
-        )[1]
+        xml_account_id = self.imd_obj.read(
+            self.cursor, self.uid,
+            self.imd_obj.search(
+                self.cursor, self.uid,
+                [('module', '=', 'som_sync_openerp'), ('name', '=', 'account_account_iva')],
+                limit=1
+            )[0],
+            ['res_id']
+        )['res_id']
         account = self.account_obj.read(
             self.cursor, self.uid, ensured_id,
             ['name', 'code', 'company_id', 'currency_mode', 'type']


### PR DESCRIPTION
## Objectiu
Necessitem que els comptes comptables queden normalitzats a 9 digits quan es sincronitzen en Odoo.
Es requerit per aplicar aquest canvi que els comptes comptables ja sincronitzats en Odoo s'actualitzen a la lonngitud configurada, per evitar problemes i duplicitats de comptes comptables al ser normalitzats.

## Targeta on es demana o Incidència
https://somenergia.openproject.com/wp/1708

## Comportament antic
Es sincronitzaven tal com estaven, a 12 dígits

## Comportament nou
Es normalitzen a una longitud configurable, per defecte 9 dígits que és com es vol treballar en Odoo.

## Comprovacions

- [x] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [x] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/som_sync_openerp_modules/pull/46?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds configurable account-code normalization for Odoo sync. The main changes are:

- New `res.config` value for the target normalized length.
- Migration to load the default normalization config.
- Account code normalization in endpoint suffixes and outgoing sync payloads.
- Tests for normalization, custom lengths, and local collision fallback.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

This is close, but the existing-account sync path can still behave incorrectly.

- Enabling the new default can make already-synced accounts use a different remote lookup key.
- The sync can miss the existing Odoo account and then create a duplicate or fail instead of updating it.
- The new local collision guard does not cover this remote identity migration case.

som_sync_openerp/models/account_account.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_sync_openerp/models/account_account.py | Adds account-code normalization and applies it to account sync identity and payload values. |
| som_sync_openerp/migrations/5.0.25.5.0/post-0006_update_account_code_normalization_config.py | Adds a migration that reloads module data for the normalization config. |
| som_sync_openerp/data/som_sync_openerp_data.xml | Adds the default normalized account-code length config record. |
| som_sync_openerp/tests/tests_account_account.py | Adds tests for normalization behavior and sync payload output. |

</details>

<sub>Reviews (3): Last reviewed commit: ["🦺 avoid account code normalization when..."](https://github.com/som-energia/som_sync_openerp_modules/commit/e5cc4a2a2ba04037edac90ff4f89059c5ae50333) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42727263)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->