### PR TITLE
✨ Add odoo_last_sync_endpoint field to OdooSync model

### DIFF
--- a/som_sync_openerp/migrations/5.0.25.5.0/post-0007_add_odoo_last_sync_endpoint_field.py
+++ b/som_sync_openerp/migrations/5.0.25.5.0/post-0007_add_odoo_last_sync_endpoint_field.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from oopgrade.oopgrade import load_data
+from tools import config
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+    if config.updating_all:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+    logger.info('Loading view XML with new odoo_last_sync_endpoint field')
+    xmls = [
+        'views/odoo_sync_view.xml',
+    ]
+    for xml_path in xmls:
+        load_data(
+            cursor,
+            'som_sync_openerp',
+            xml_path,
+            idref=None,
+            mode='update'
+        )
+    logger.info('odoo_sync_view.xml loaded successfully')
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_sync_openerp/migrations/5.0.25.5.0/post-0007_add_odoo_last_sync_endpoint_field.py
+++ b/som_sync_openerp/migrations/5.0.25.5.0/post-0007_add_odoo_last_sync_endpoint_field.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+import pooler
 
 from oopgrade.oopgrade import load_data
 from tools import config
@@ -12,6 +13,15 @@ def up(cursor, installed_version):
         return
 
     logger = logging.getLogger('openerp.migration')
+    logger.info('Creating pooler')
+    pool = pooler.get_pool(cursor.dbname)
+
+    logger.info('Creating new odoo_last_sync_endpoint field in odoo.sync')
+    pool.get('odoo.sync')._auto_init(
+        cursor, context={'module': 'som_sync_openerp'}
+    )
+    logger.info('Field created successfully')
+
     logger.info('Loading view XML with new odoo_last_sync_endpoint field')
     xmls = [
         'views/odoo_sync_view.xml',

--- a/som_sync_openerp/models/odoo_sync.py
+++ b/som_sync_openerp/models/odoo_sync.py
@@ -533,7 +533,7 @@ class OdooSync(osv.osv):
                     odoo_id = self.get_odoo_id_by_erp_id_from_odoo(
                         cursor, uid, model, data.get('pnt_erp_id', False))
                     if odoo_id:
-                        return odoo_id, False, False
+                        return odoo_id, False, url_base
                     else:
                         return False, response.text, url_base
             else:

--- a/som_sync_openerp/models/odoo_sync.py
+++ b/som_sync_openerp/models/odoo_sync.py
@@ -525,6 +525,7 @@ class OdooSync(osv.osv):
                     odoo_id = data_response['data']['odoo_id']
                     return odoo_id, response.text, url_base
             elif response.status_code == 409 and model == 'account.invoice':
+                # 409 Conflicto - ERP ID o número de factura duplicado: Actualitzem odoo_id.
                 data_response = response.json()
                 if data_response and 'success' in data_response and \
                         not data_response.get('success', False) and \

--- a/som_sync_openerp/models/odoo_sync.py
+++ b/som_sync_openerp/models/odoo_sync.py
@@ -401,17 +401,18 @@ class OdooSync(osv.osv):
                     odoo_metadata.pop('company_name', False)
                     dict_to_patch = self.get_dict_to_patch(cursor, uid, erp_data, odoo_metadata)
                     if dict_to_patch:
-                        success, msg = self.update_odoo_record(
+                        success, msg, endpoint = self.update_odoo_record(
                             cursor, uid, model, odoo_id, erp_id, dict_to_patch, context)
                         sync_vals.update({
                             'sync_state': 'synced' if success else 'error',
                             'odoo_last_update_result': self.format_response(msg),
                             'update_last_sync': True,
                             'odoo_last_sync_request': self.format_response(dict_to_patch),
+                            'odoo_last_sync_endpoint': endpoint,
                         })
             else:
                 # Case: Record does not exist in Odoo, proceed to create it
-                odoo_id, msg = self.create_odoo_record(
+                odoo_id, msg, endpoint = self.create_odoo_record(
                     cursor, uid, model, erp_data, context=context)
                 if odoo_id:
                     erp_id = openerp_id
@@ -430,6 +431,7 @@ class OdooSync(osv.osv):
 
                 sync_vals.update({
                     'odoo_last_sync_request': self.format_response(erp_data),
+                    'odoo_last_sync_endpoint': endpoint,
                     'sync_state': sync_state,
                 })
 
@@ -521,9 +523,8 @@ class OdooSync(osv.osv):
                 if data_response and 'success' in data_response and \
                         data_response.get('success', False):
                     odoo_id = data_response['data']['odoo_id']
-                    return odoo_id, response.text
+                    return odoo_id, response.text, url_base
             elif response.status_code == 409 and model == 'account.invoice':
-                # 409 Conflicto - ERP ID o número de factura duplicado: Actualitzem odoo_id.
                 data_response = response.json()
                 if data_response and 'success' in data_response and \
                         not data_response.get('success', False) and \
@@ -531,14 +532,14 @@ class OdooSync(osv.osv):
                     odoo_id = self.get_odoo_id_by_erp_id_from_odoo(
                         cursor, uid, model, data.get('pnt_erp_id', False))
                     if odoo_id:
-                        return odoo_id, False
+                        return odoo_id, False, False
                     else:
-                        return False, response.text
+                        return False, response.text, url_base
             else:
-                return False, response.text
+                return False, response.text, url_base
         else:
             raise CreationNotSupportedException(model)
-        return False, False
+        return False, False, False
 
     def update_odoo_record(self, cursor, uid, model, odoo_id, erp_id, data, context=None):
         if context is None:
@@ -556,8 +557,8 @@ class OdooSync(osv.osv):
         if response.status_code == 200:
             data = response.json()
             if data and 'success' in data and data.get('success', False):
-                return True, response.text
-        return False, response.text
+                return True, response.text, url_base
+        return False, response.text, url_base
 
     def exists_in_odoo(self, cursor, uid, model, url_sufix, erp_id, context=None):
         if context is None:
@@ -650,6 +651,11 @@ class OdooSync(osv.osv):
                 'odoo_last_update_result': context['odoo_last_update_result'],
             })
 
+        if context.get('odoo_last_sync_endpoint'):
+            vals.update({
+                'odoo_last_sync_endpoint': context['odoo_last_sync_endpoint'],
+            })
+
         with Sudo(uid=1, gid=0):
             return self.create(cursor, uid, vals)
 
@@ -686,6 +692,12 @@ class OdooSync(osv.osv):
         if context.get('odoo_last_sync_request'):
             vals.update({
                 'odoo_last_sync_request': context['odoo_last_sync_request'],
+            })
+            update = True
+
+        if context.get('odoo_last_sync_endpoint'):
+            vals.update({
+                'odoo_last_sync_endpoint': context['odoo_last_sync_endpoint'],
             })
             update = True
 
@@ -950,6 +962,7 @@ class OdooSync(osv.osv):
         # Resultat de l'error de la última actualització
         'odoo_last_update_result': fields.text('Odoo last update result'),
         'odoo_last_sync_request': fields.text('Odoo last sync request'),
+        'odoo_last_sync_endpoint': fields.char('Odoo last sync endpoint', size=512),
         'sync_state': fields.selection([
             ('draft', 'Draft'),
             ('error', 'Error'),

--- a/som_sync_openerp/tests/tests_odoo_sync.py
+++ b/som_sync_openerp/tests/tests_odoo_sync.py
@@ -548,7 +548,7 @@ class TestOdooSync(testing.OOTestCaseWithCursor):
             'name': u'ASUStek',
         }
         mock_exists_in_odoo.return_value = (False, False, False)
-        mock_create_odoo_record.return_value = (4321, '')
+        mock_create_odoo_record.return_value = (4321, '', 'http://example.com/api/res.partner')
 
         odoo_id, erp_id = self.sync_obj.syncronize_sync(
             self.cursor, self.uid, 'res.partner', 'sync', partner_id, context={}
@@ -584,7 +584,8 @@ class TestOdooSync(testing.OOTestCaseWithCursor):
         }
         mock_exists_in_odoo.return_value = (9999, partner_id, {'name': u'Old'})
         mock_get_dict_to_patch.return_value = {'name': u'ASUStek'}
-        mock_update_odoo_record.return_value = (True, '')
+        mock_update_odoo_record.return_value = (
+            True, '', 'http://example.com/api/res.partner/9999/partner_id')
 
         odoo_id, erp_id = self.sync_obj.syncronize_sync(
             self.cursor, self.uid, 'res.partner', 'write', partner_id, context={}
@@ -664,7 +665,7 @@ class TestOdooSync(testing.OOTestCaseWithCursor):
             'code': u'4300TEST',
             'name': u'Account Test'
         }
-        mock_create_odoo_record.return_value = (321, '')
+        mock_create_odoo_record.return_value = (321, '', 'http://example.com/api/res.partner')
 
         odoo_id, erp_id = self.sync_obj.syncronize_sync(
             self.cursor, self.uid, 'account.account', 'sync', account_id, context={}
@@ -701,7 +702,7 @@ class TestOdooSync(testing.OOTestCaseWithCursor):
         mock_get_model_vals_to_sync.return_value = {
             'pnt_erp_id': payment_order_id,
         }
-        mock_create_odoo_record.return_value = (4321, '')
+        mock_create_odoo_record.return_value = (4321, '', 'http://example.com/api/res.partner')
         mock_get_sync_state.return_value = 'pending'
 
         odoo_id, erp_id = self.sync_obj.syncronize_sync(
@@ -737,7 +738,7 @@ class TestOdooSync(testing.OOTestCaseWithCursor):
         mock_get_model_vals_to_sync.return_value = {
             'pnt_erp_id': payment_order_id,
         }
-        mock_create_odoo_record.return_value = (4321, '')
+        mock_create_odoo_record.return_value = (4321, '', 'http://example.com/api/res.partner')
         mock_get_sync_state.return_value = 'pending'
 
         odoo_id, erp_id = self.sync_obj.syncronize_sync(
@@ -765,7 +766,7 @@ class TestOdooSync(testing.OOTestCaseWithCursor):
         mock_get_model_vals_to_sync.return_value = {
             'pnt_erp_id': payment_order_id,
         }
-        mock_create_odoo_record.return_value = (4321, '')
+        mock_create_odoo_record.return_value = (4321, '', 'http://example.com/api/res.partner')
         mock_get_sync_state.return_value = 'synced'
 
         odoo_id, erp_id = self.sync_obj.syncronize_sync(

--- a/som_sync_openerp/views/odoo_sync_view.xml
+++ b/som_sync_openerp/views/odoo_sync_view.xml
@@ -16,6 +16,7 @@
                     <field name="odoo_created_at" />
                     <field name="odoo_updated_at" />
                     <field name="odoo_last_sync_request" />
+                    <field name="odoo_last_sync_endpoint" widget="url"/>
                     <field name="odoo_last_update_result" />
                     <field name="sync_state" />
                 </form>


### PR DESCRIPTION
## Resum

Afegim el camp `odoo_last_sync_endpoint` al model `odoo.sync` per guardar l'endpoint API cridat quan es sincronitza un objecte amb Odoo.

## Canvis

### Model `odoo_sync.py`
- Nou camp `odoo_last_sync_endpoint` (char 512) als _columns
- Modificats `create_odoo_record()` i `update_odoo_record()` per retornar l'endpoint utilitzat
- `syncronize_sync()` ara emmagatzema l'endpoint a `sync_vals`
- `_create_sync_record()` i `_build_update_vals()` persisteixen el nou camp

### Vista `odoo_sync_view.xml`
- Afegit camp al form amb widget="url" per visualització clicable

## Relatiu a

Fixes #47

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/som_sync_openerp_modules/pull/48?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR records the last Odoo API endpoint used during sync. The main changes are:

- Adds `odoo_last_sync_endpoint` to the `odoo.sync` model.
- Returns the endpoint from create and update sync calls.
- Persists the endpoint in sync create and update helpers.
- Shows the endpoint in the sync form as a clickable URL.
- Updates affected sync tests for the new return shape.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_sync_openerp/models/odoo_sync.py | Adds endpoint return values, persistence, and the new sync endpoint field. |
| som_sync_openerp/tests/tests_odoo_sync.py | Updates affected sync mocks to include the returned endpoint. |
| som_sync_openerp/views/odoo_sync_view.xml | Displays the new sync endpoint field in the form view. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Fix: return url\_base instead of False on..."](https://github.com/som-energia/som_sync_openerp_modules/commit/45013741a0fe66d305964572905eeadafc208563) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42968928)</sub>

<!-- /greptile_comment -->