### PR TITLE
👔 add bank concile movement to N57 remesa

### DIFF
--- a/som_sync_openerp/data/som_sync_openerp_data.xml
+++ b/som_sync_openerp/data/som_sync_openerp_data.xml
@@ -146,6 +146,13 @@
                 Odoo destination journal for Norma57 remittances.
             </field>
         </record>
+        <record id="odoo_norma57_payment_entry_journal" model="res.config">
+            <field name="name">odoo_norma57_payment_entry_journal</field>
+            <field name="value">0</field>
+            <field name="description">
+                Odoo general journal used to create Norma57 payment entries.
+            </field>
+        </record>
         <record id="odoo_default_erp_payment_term" model="res.config">
             <field name="name">odoo_default_erp_payment_term</field>
             <field name="value">0</field>

--- a/som_sync_openerp/migrations/5.0.25.5.0/post-0008_add_norma57_payment_entry_sync_fields.py
+++ b/som_sync_openerp/migrations/5.0.25.5.0/post-0008_add_norma57_payment_entry_sync_fields.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+import logging
+import pooler
+
+from oopgrade.oopgrade import load_data
+from tools import config
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+    if config.updating_all:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+    logger.info('Creating pooler')
+    pool = pooler.get_pool(cursor.dbname)
+
+    logger.info(
+        'Creating Norma57 payment entry sync fields on model odoo.sync'
+    )
+    pool.get('odoo.sync')._auto_init(
+        cursor, context={'module': 'som_sync_openerp'}
+    )
+    logger.info('Norma57 payment entry sync fields created successfully')
+
+    logger.info('Loading XML data with Norma57 payment entry config')
+    load_data(
+        cursor,
+        'som_sync_openerp',
+        'data/som_sync_openerp_data.xml',
+        idref=None,
+        mode='update'
+    )
+    logger.info('Norma57 payment entry config loaded successfully')
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/som_sync_openerp/models/norma57_file.py
+++ b/som_sync_openerp/models/norma57_file.py
@@ -140,6 +140,14 @@ class Norma57File(osv.osv):
                 context=context,
             )
 
+    def _queue_payment_entry_retry(self, cr, uid, sync_id, last_result, context=None):
+        if context is None:
+            context = {}
+        self._update_payment_entry_sync_fields(
+            cr, uid, sync_id, last_result=last_result, context=context)
+        return self._set_payment_entry_retry_pending(
+            cr, uid, sync_id, context=context)
+
     def _build_payment_entry_payload(self, cr, uid, norma57_file, context=None):
         if context is None:
             context = {}
@@ -366,14 +374,36 @@ class Norma57File(osv.osv):
         result = sync_obj.poll_payment_order_status_sync(
             cr, uid, self._name, erp_id, context=context)
         if result:
-            payment_entry_odoo_id = self._sync_norma57_payment_entry_if_needed(
-                cr, uid, erp_id, context=context)
             sync_id = self._get_sync_record_id(cr, uid, erp_id, context=context)
+            try:
+                payment_entry_odoo_id = self._sync_norma57_payment_entry_if_needed(
+                    cr, uid, erp_id, context=context)
+            except Exception as exc:
+                if sync_id:
+                    sync_record = sync_obj.browse(cr, uid, sync_id, context=context)
+                    if sync_record.sync_state == 'synced':
+                        self._queue_payment_entry_retry(
+                            cr,
+                            uid,
+                            sync_id,
+                            last_result=str(exc),
+                            context=context,
+                        )
+                logger.exception(
+                    'Error creating Norma57 payment entry for sync %s',
+                    erp_id,
+                )
+                return result
             if sync_id and not payment_entry_odoo_id:
                 sync_record = sync_obj.browse(cr, uid, sync_id, context=context)
                 if sync_record.sync_state == 'synced':
-                    self._set_payment_entry_retry_pending(
-                        cr, uid, sync_id, context=context)
+                    self._queue_payment_entry_retry(
+                        cr,
+                        uid,
+                        sync_id,
+                        last_result='Retrying Norma57 payment entry creation',
+                        context=context,
+                    )
         return result
 
 

--- a/som_sync_openerp/models/norma57_file.py
+++ b/som_sync_openerp/models/norma57_file.py
@@ -1,7 +1,6 @@
 #  -*- coding: utf-8 -*-
 from oorq.decorators import job
 from osv import osv
-import json
 from service.security import Sudo
 
 from .odoo_exceptions import ForeingKeyNotAvailable
@@ -227,15 +226,8 @@ class Norma57File(osv.osv):
             return result['odoo_id']
 
         response_text = result.get('response_text') or ''
-        existing_odoo_id = False
-        if response_text:
-            try:
-                response_json = json.loads(response_text)
-            except Exception:
-                response_json = {}
-            if response_json.get('error_code') == 'DUPLICATE_KEY_VALUE':
-                existing_odoo_id = self._get_existing_payment_entry_odoo_id(
-                    cr, uid, payload['pnt_erp_id'], context=context)
+        existing_odoo_id = self._get_existing_payment_entry_odoo_id(
+            cr, uid, payload['pnt_erp_id'], context=context)
 
         if existing_odoo_id:
             self._update_payment_entry_sync_fields(

--- a/som_sync_openerp/models/norma57_file.py
+++ b/som_sync_openerp/models/norma57_file.py
@@ -129,6 +129,18 @@ class Norma57File(osv.osv):
         with Sudo(uid=1, gid=0):
             return self.pool.get('odoo.sync').write(cr, uid, [sync_id], vals, context=context)
 
+    def _set_payment_entry_retry_pending(self, cr, uid, sync_id, context=None):
+        if context is None:
+            context = {}
+        with Sudo(uid=1, gid=0):
+            return self.pool.get('odoo.sync').write(
+                cr,
+                uid,
+                [sync_id],
+                {'sync_state': 'pending'},
+                context=context,
+            )
+
     def _build_payment_entry_payload(self, cr, uid, norma57_file, context=None):
         if context is None:
             context = {}
@@ -362,7 +374,14 @@ class Norma57File(osv.osv):
         result = sync_obj.poll_payment_order_status_sync(
             cr, uid, self._name, erp_id, context=context)
         if result:
-            self._sync_norma57_payment_entry_if_needed(cr, uid, erp_id, context=context)
+            payment_entry_odoo_id = self._sync_norma57_payment_entry_if_needed(
+                cr, uid, erp_id, context=context)
+            sync_id = self._get_sync_record_id(cr, uid, erp_id, context=context)
+            if sync_id and not payment_entry_odoo_id:
+                sync_record = sync_obj.browse(cr, uid, sync_id, context=context)
+                if sync_record.sync_state == 'synced':
+                    self._set_payment_entry_retry_pending(
+                        cr, uid, sync_id, context=context)
         return result
 
 

--- a/som_sync_openerp/models/norma57_file.py
+++ b/som_sync_openerp/models/norma57_file.py
@@ -70,18 +70,13 @@ class Norma57File(osv.osv):
             raise Exception('odoo_norma57_payment_entry_journal is not configured')
         return journal_odoo_id
 
-    def _get_payment_entry_account_code_candidates(self, code):
+    def _get_payment_entry_account_code_pattern(self, code):
         raw_code = (code or '').strip()
-        normalized = raw_code.replace('.', '')
-        candidates = [raw_code]
-        if normalized and normalized not in candidates:
-            candidates.append(normalized)
-        for target_len in (6, 9):
-            if normalized and len(normalized) < target_len:
-                padded = normalized.ljust(target_len, '0')
-                if padded not in candidates:
-                    candidates.append(padded)
-        return candidates
+        if '.' not in raw_code:
+            return raw_code
+        prefix, suffix = raw_code.split('.', 1)
+        suffix = suffix[-1:] if suffix else ''
+        return '{}%{}'.format(prefix, suffix)
 
     def _get_payment_entry_account_odoo_id_by_code(self, cr, uid, code, context=None):
         if context is None:
@@ -89,17 +84,20 @@ class Norma57File(osv.osv):
         account_obj = self.pool.get('account.account')
         sync_obj = self.pool.get('odoo.sync')
 
-        for candidate in self._get_payment_entry_account_code_candidates(code):
-            account_ids = account_obj.search(cr, uid, [('code', '=', candidate)], context=context)
-            if not account_ids:
-                continue
-            odoo_id = sync_obj.get_odoo_id_by_erp_id(
-                cr, uid, 'account.account', account_ids[0])
-            if odoo_id:
-                return odoo_id
-            raise ForeingKeyNotAvailable('account.account,{}'.format(account_ids[0]))
+        account_code_pattern = self._get_payment_entry_account_code_pattern(code)
+        account_ids = account_obj.search(
+            cr, uid, [('code', 'like', account_code_pattern)], context=context)
+        if not account_ids:
+            raise Exception(
+                'Account code pattern {} not found for Norma57 payment entry'.format(
+                    account_code_pattern)
+            )
 
-        raise Exception('Account code {} not found for Norma57 payment entry'.format(code))
+        odoo_id = sync_obj.get_odoo_id_by_erp_id(
+            cr, uid, 'account.account', account_ids[0])
+        if odoo_id:
+            return odoo_id
+        raise ForeingKeyNotAvailable('account.account,{}'.format(account_ids[0]))
 
     def _get_payment_entry_erp_id(self, norma57_id):
         return self.PAYMENT_ENTRY_ERP_ID_OFFSET + int(norma57_id)

--- a/som_sync_openerp/models/norma57_file.py
+++ b/som_sync_openerp/models/norma57_file.py
@@ -1,6 +1,7 @@
 #  -*- coding: utf-8 -*-
 from oorq.decorators import job
 from osv import osv
+import json
 from service.security import Sudo
 
 from .odoo_exceptions import ForeingKeyNotAvailable
@@ -14,6 +15,10 @@ logger = logging.getLogger('openerp.odoo.sync')
 class Norma57File(osv.osv):
     _name = 'norma57.file'
     _inherit = 'norma57.file'
+
+    PAYMENT_ENTRY_ACCOUNT_DEBIT_CODE = '572.9'
+    PAYMENT_ENTRY_ACCOUNT_CREDIT_CODE = '570.0'
+    PAYMENT_ENTRY_ERP_ID_OFFSET = 900000000
 
     MAPPING_FIELDS_TO_SYNC = {
         'id': 'pnt_erp_id',
@@ -57,6 +62,190 @@ class Norma57File(osv.osv):
         if not payment_method_line_id:
             raise Exception('odoo_norma57_payment_method is not configured')
         return payment_method_line_id
+
+    def _get_payment_entry_journal_odoo_id(self, cr, uid, context=None):
+        journal_odoo_id = self._get_config_odoo_id(
+            cr, uid, 'odoo_norma57_payment_entry_journal', context=context)
+        if not journal_odoo_id:
+            raise Exception('odoo_norma57_payment_entry_journal is not configured')
+        return journal_odoo_id
+
+    def _get_payment_entry_account_code_candidates(self, code):
+        raw_code = (code or '').strip()
+        normalized = raw_code.replace('.', '')
+        candidates = [raw_code]
+        if normalized and normalized not in candidates:
+            candidates.append(normalized)
+        for target_len in (6, 9):
+            if normalized and len(normalized) < target_len:
+                padded = normalized.ljust(target_len, '0')
+                if padded not in candidates:
+                    candidates.append(padded)
+        return candidates
+
+    def _get_payment_entry_account_odoo_id_by_code(self, cr, uid, code, context=None):
+        if context is None:
+            context = {}
+        account_obj = self.pool.get('account.account')
+        sync_obj = self.pool.get('odoo.sync')
+
+        for candidate in self._get_payment_entry_account_code_candidates(code):
+            account_ids = account_obj.search(cr, uid, [('code', '=', candidate)], context=context)
+            if not account_ids:
+                continue
+            odoo_id = sync_obj.get_odoo_id_by_erp_id(
+                cr, uid, 'account.account', account_ids[0])
+            if odoo_id:
+                return odoo_id
+            raise ForeingKeyNotAvailable('account.account,{}'.format(account_ids[0]))
+
+        raise Exception('Account code {} not found for Norma57 payment entry'.format(code))
+
+    def _get_payment_entry_erp_id(self, norma57_id):
+        return self.PAYMENT_ENTRY_ERP_ID_OFFSET + int(norma57_id)
+
+    def _get_payment_entry_label(self, norma57_file):
+        return '[REMESA] {}'.format(norma57_file.name or '')
+
+    def _get_sync_record_id(self, cr, uid, erp_id, context=None):
+        if context is None:
+            context = {}
+        sync_obj = self.pool.get('odoo.sync')
+        sync_ids = sync_obj.search(cr, uid, [
+            ('model.model', '=', self._name),
+            ('res_id', '=', erp_id),
+        ], limit=1, context=context)
+        return sync_ids[0] if sync_ids else False
+
+    def _update_payment_entry_sync_fields(
+            self, cr, uid, sync_id, entry_odoo_id=False, last_result=False, context=None):
+        if context is None:
+            context = {}
+        vals = {}
+        if entry_odoo_id is not False:
+            vals['pnt_norma57_payment_entry_odoo_id'] = entry_odoo_id
+        if last_result is not False:
+            vals['pnt_norma57_payment_entry_last_result'] = last_result
+        if not vals:
+            return False
+        with Sudo(uid=1, gid=0):
+            return self.pool.get('odoo.sync').write(cr, uid, [sync_id], vals, context=context)
+
+    def _build_payment_entry_payload(self, cr, uid, norma57_file, context=None):
+        if context is None:
+            context = {}
+
+        label = self._get_payment_entry_label(norma57_file)
+        amount = round(sum([
+            abs(line.amount) for line in norma57_file.lines if line.state == 'confirmed'
+        ]), 2)
+        if amount <= 0:
+            raise Exception('Norma57 file has no positive confirmed amount for payment entry')
+
+        debit_account_odoo_id = self._get_payment_entry_account_odoo_id_by_code(
+            cr, uid, self.PAYMENT_ENTRY_ACCOUNT_DEBIT_CODE, context=context)
+        credit_account_odoo_id = self._get_payment_entry_account_odoo_id_by_code(
+            cr, uid, self.PAYMENT_ENTRY_ACCOUNT_CREDIT_CODE, context=context)
+
+        return {
+            'pnt_erp_id': self._get_payment_entry_erp_id(norma57_file.id),
+            'number': label,
+            'date': norma57_file.header_presentation_date,
+            'journal_id': self._get_payment_entry_journal_odoo_id(cr, uid, context=context),
+            'ref': label,
+            'lines': [
+                {
+                    'account_id': debit_account_odoo_id,
+                    'name': label,
+                    'debit': amount,
+                },
+                {
+                    'account_id': credit_account_odoo_id,
+                    'name': label,
+                    'credit': amount,
+                },
+            ],
+        }
+
+    def _create_payment_entry_in_odoo(self, cr, uid, payload, context=None):
+        if context is None:
+            context = {}
+        sync_obj = self.pool.get('odoo.sync')
+        odoo_id, response_text, url_base = sync_obj.create_odoo_record(
+            cr, uid, 'account.move', payload, context=context)
+        return {
+            'success': bool(odoo_id),
+            'odoo_id': odoo_id,
+            'response_text': response_text,
+            'url': url_base,
+        }
+
+    def _get_existing_payment_entry_odoo_id(self, cr, uid, payment_entry_erp_id, context=None):
+        if context is None:
+            context = {}
+        sync_obj = self.pool.get('odoo.sync')
+        return sync_obj.get_odoo_id_by_erp_id_from_odoo(
+            cr, uid, 'account.move', payment_entry_erp_id)
+
+    def _sync_norma57_payment_entry_if_needed(self, cr, uid, erp_id, context=None):
+        if context is None:
+            context = {}
+
+        sync_obj = self.pool.get('odoo.sync')
+        sync_id = self._get_sync_record_id(cr, uid, erp_id, context=context)
+        if not sync_id:
+            return False
+
+        sync_record = sync_obj.browse(cr, uid, sync_id, context=context)
+        if sync_record.sync_state != 'synced':
+            return False
+        if sync_record.pnt_norma57_payment_entry_odoo_id:
+            return sync_record.pnt_norma57_payment_entry_odoo_id
+
+        norma57_file = self.browse(cr, uid, erp_id, context=context)
+        payload = self._build_payment_entry_payload(cr, uid, norma57_file, context=context)
+        result = self._create_payment_entry_in_odoo(cr, uid, payload, context=context)
+        if result['success'] and result['odoo_id']:
+            self._update_payment_entry_sync_fields(
+                cr,
+                uid,
+                sync_id,
+                entry_odoo_id=result['odoo_id'],
+                last_result=result['response_text'] or 'created',
+                context=context,
+            )
+            return result['odoo_id']
+
+        response_text = result.get('response_text') or ''
+        existing_odoo_id = False
+        if response_text:
+            try:
+                response_json = json.loads(response_text)
+            except Exception:
+                response_json = {}
+            if response_json.get('error_code') == 'DUPLICATE_KEY_VALUE':
+                existing_odoo_id = self._get_existing_payment_entry_odoo_id(
+                    cr, uid, payload['pnt_erp_id'], context=context)
+
+        if existing_odoo_id:
+            self._update_payment_entry_sync_fields(
+                cr,
+                uid,
+                sync_id,
+                entry_odoo_id=existing_odoo_id,
+                last_result=response_text or 'duplicate entry recovered',
+                context=context,
+            )
+            return existing_odoo_id
+
+        self._update_payment_entry_sync_fields(
+            cr,
+            uid,
+            sync_id,
+            last_result=response_text or 'Error creating Norma57 payment entry in Odoo',
+            context=context,
+        )
+        return False
 
     def _get_line_invoice_erp_id(self, cr, uid, line, context=None):
         if context is None:
@@ -172,8 +361,11 @@ class Norma57File(osv.osv):
             context = {}
 
         sync_obj = self.pool.get('odoo.sync')
-        return sync_obj.poll_payment_order_status_sync(
+        result = sync_obj.poll_payment_order_status_sync(
             cr, uid, self._name, erp_id, context=context)
+        if result:
+            self._sync_norma57_payment_entry_if_needed(cr, uid, erp_id, context=context)
+        return result
 
 
 Norma57File()

--- a/som_sync_openerp/models/odoo_sync.py
+++ b/som_sync_openerp/models/odoo_sync.py
@@ -16,6 +16,7 @@ FF_ENABLE_ODOO_SYNC = True  # TODO: as variable in res.config ??
 # Mapping of models entities to update erp_id in Odoo: key -> erp model, value -> odoo entity name
 MAPPING_MODELS_ENTITIES = {
     'account.account': 'account',
+    'account.move': 'entry',
     'account.invoice': 'invoice',
     'payment.order': 'payment_orders',
     'norma57.file': 'payment_orders',
@@ -955,6 +956,12 @@ class OdooSync(osv.osv):
         'model': fields.many2one('ir.model', 'Model'),
         'res_id': fields.integer('ERP id'),
         'odoo_id': fields.integer('Odoo id'),
+        'pnt_norma57_payment_entry_odoo_id': fields.integer(
+            'Norma57 payment entry Odoo id'
+        ),
+        'pnt_norma57_payment_entry_last_result': fields.text(
+            'Norma57 payment entry last result'
+        ),
         # Aquest camp indica la última vegada que hem fet sync amb Odoo (s'hagin modificat o no les dades)  # noqa: E501
         'odoo_last_sync_at': fields.datetime('Odoo last sync at'),
         # Aquests camps indiquen la data de creacio i ultima modificacio al Odoo, no la data d'actualitzció de l'odoo_id a OpenERP  # noqa: E501

--- a/som_sync_openerp/tests/tests_norma57_file.py
+++ b/som_sync_openerp/tests/tests_norma57_file.py
@@ -161,6 +161,16 @@ class TestNorma57File(testing.OOTestCaseWithCursor):
     def test_get_payment_entry_erp_id_uses_offset(self):
         self.assertEqual(self.n57_obj._get_payment_entry_erp_id(17), 900000017)
 
+    def test_get_payment_entry_account_code_pattern_uses_like_format(self):
+        self.assertEqual(
+            self.n57_obj._get_payment_entry_account_code_pattern('572.9'),
+            '572%9'
+        )
+        self.assertEqual(
+            self.n57_obj._get_payment_entry_account_code_pattern('570.0'),
+            '570%0'
+        )
+
     def test_sync_norma57_payment_entry_if_needed_skips_when_entry_already_exists(self):
         norma57_id = self._create_norma57_file()
         sync_id = self._create_norma57_sync(norma57_id)

--- a/som_sync_openerp/tests/tests_norma57_file.py
+++ b/som_sync_openerp/tests/tests_norma57_file.py
@@ -261,13 +261,43 @@ class TestNorma57File(testing.OOTestCaseWithCursor):
             self, mock_poll):
         norma57_id = self._create_norma57_file()
         mock_poll.return_value = True
+        self._create_norma57_sync(norma57_id)
 
         with mock.patch.object(
                 type(self.n57_obj),
                 '_sync_norma57_payment_entry_if_needed') as mock_payment_entry_sync:
+            mock_payment_entry_sync.return_value = 4321
             result = self.n57_obj.update_pending_state_sync(self.cursor, self.uid, norma57_id)
 
         self.assertTrue(result)
         mock_payment_entry_sync.assert_called_once_with(
             self.cursor, self.uid, norma57_id, context={}
         )
+
+    @mock.patch.object(odoo_sync.OdooSync, 'poll_payment_order_status_sync')
+    def test_update_pending_state_sync_sets_pending_when_entry_creation_fails(
+            self, mock_poll):
+        norma57_id = self._create_norma57_file()
+        sync_id = self._create_norma57_sync(norma57_id, sync_state='pending')
+        mock_poll.side_effect = self._mock_poll_to_synced
+
+        with mock.patch.object(
+                type(self.n57_obj),
+                '_sync_norma57_payment_entry_if_needed') as mock_payment_entry_sync:
+            mock_payment_entry_sync.return_value = False
+            result = self.n57_obj.update_pending_state_sync(self.cursor, self.uid, norma57_id)
+
+        sync_record = self.sync_obj.browse(self.cursor, self.uid, sync_id)
+        self.assertTrue(result)
+        self.assertEqual(sync_record.sync_state, 'pending')
+
+    def _mock_poll_to_synced(self, cr, uid, model_name, erp_id, context=None):
+        self.sync_obj.update_odoo_id(
+            cr,
+            uid,
+            model_name,
+            erp_id,
+            321,
+            context={'sync_state': 'synced', 'update_last_sync': True},
+        )
+        return True

--- a/som_sync_openerp/tests/tests_norma57_file.py
+++ b/som_sync_openerp/tests/tests_norma57_file.py
@@ -319,6 +319,28 @@ class TestNorma57File(testing.OOTestCaseWithCursor):
         sync_record = self.sync_obj.browse(self.cursor, self.uid, sync_id)
         self.assertTrue(result)
         self.assertEqual(sync_record.sync_state, 'pending')
+        self.assertEqual(
+            sync_record.pnt_norma57_payment_entry_last_result,
+            'Retrying Norma57 payment entry creation'
+        )
+
+    @mock.patch.object(odoo_sync.OdooSync, 'poll_payment_order_status_sync')
+    def test_update_pending_state_sync_sets_pending_when_entry_creation_raises(
+            self, mock_poll):
+        norma57_id = self._create_norma57_file()
+        sync_id = self._create_norma57_sync(norma57_id, sync_state='pending')
+        mock_poll.side_effect = self._mock_poll_to_synced
+
+        with mock.patch.object(
+                type(self.n57_obj),
+                '_sync_norma57_payment_entry_if_needed') as mock_payment_entry_sync:
+            mock_payment_entry_sync.side_effect = Exception('boom')
+            result = self.n57_obj.update_pending_state_sync(self.cursor, self.uid, norma57_id)
+
+        sync_record = self.sync_obj.browse(self.cursor, self.uid, sync_id)
+        self.assertTrue(result)
+        self.assertEqual(sync_record.sync_state, 'pending')
+        self.assertEqual(sync_record.pnt_norma57_payment_entry_last_result, 'boom')
 
     def _mock_poll_to_synced(self, cr, uid, model_name, erp_id, context=None):
         self.sync_obj.update_odoo_id(

--- a/som_sync_openerp/tests/tests_norma57_file.py
+++ b/som_sync_openerp/tests/tests_norma57_file.py
@@ -234,6 +234,35 @@ class TestNorma57File(testing.OOTestCaseWithCursor):
             '{"error_code": "DUPLICATE_KEY_VALUE"}'
         )
 
+    def test_sync_norma57_payment_entry_if_needed_recovers_existing_entry_without_json_body(self):
+        norma57_id = self._create_norma57_file()
+        sync_id = self._create_norma57_sync(norma57_id)
+
+        with mock.patch.object(self.n57_obj, '_build_payment_entry_payload') as mock_payload:
+            with mock.patch.object(self.n57_obj, '_create_payment_entry_in_odoo') as mock_create:
+                with mock.patch.object(
+                        self.n57_obj,
+                        '_get_existing_payment_entry_odoo_id') as mock_get:
+                    mock_payload.return_value = {'pnt_erp_id': 900000001}
+                    mock_create.return_value = {
+                        'success': False,
+                        'odoo_id': False,
+                        'response_text': '',
+                        'url': 'http://odoo/api/v1/entries',
+                    }
+                    mock_get.return_value = 9876
+
+                    result = self.n57_obj._sync_norma57_payment_entry_if_needed(
+                        self.cursor, self.uid, norma57_id)
+
+        sync_record = self.sync_obj.browse(self.cursor, self.uid, sync_id)
+        self.assertEqual(result, 9876)
+        self.assertEqual(sync_record.pnt_norma57_payment_entry_odoo_id, 9876)
+        self.assertEqual(
+            sync_record.pnt_norma57_payment_entry_last_result,
+            'duplicate entry recovered'
+        )
+
     def test_sync_norma57_payment_entry_if_needed_stores_last_result_on_error(self):
         norma57_id = self._create_norma57_file()
         sync_id = self._create_norma57_sync(norma57_id)

--- a/som_sync_openerp/tests/tests_norma57_file.py
+++ b/som_sync_openerp/tests/tests_norma57_file.py
@@ -16,6 +16,7 @@ class TestNorma57File(testing.OOTestCaseWithCursor):
         self.n57_obj = self.openerp.pool.get('norma57.file')
         self.n57_line_obj = self.openerp.pool.get('norma57.file.line')
         self.ai_obj = self.openerp.pool.get('account.invoice')
+        self.sync_obj = self.openerp.pool.get('odoo.sync')
         super(TestNorma57File, self).setUp()
 
     def _create_norma57_file(self, name='Norma57 test'):
@@ -32,6 +33,17 @@ class TestNorma57File(testing.OOTestCaseWithCursor):
         line.resource = '{},{}'.format(resource_model, resource_id)
         return line
 
+    def _create_norma57_sync(self, norma57_id, sync_state='synced'):
+        return self.sync_obj._create_sync_record(
+            self.cursor,
+            self.uid,
+            'norma57.file',
+            norma57_id,
+            321,
+            '2026-01-15 10:00:00',
+            {'sync_state': sync_state},
+        )
+
     @mock.patch.object(odoo_sync.OdooSync, 'common_sync_model_create_update')
     def test_get_related_values_builds_simple_payment_order_payload(self, mock_sync):
         invoice_id = self.imd_obj.get_object_reference(
@@ -43,7 +55,9 @@ class TestNorma57File(testing.OOTestCaseWithCursor):
         self.conf_obj.set(self.cursor, self.uid, 'odoo_norma57_payment_method', '411')
         mock_sync.return_value = (99, invoice_id)
 
-        with mock.patch.object(type(self.ai_obj), 'process_lines_with_discrepancies') as mock_discrepancies:  # noqa: E501
+        with mock.patch.object(
+                type(self.ai_obj),
+                'process_lines_with_discrepancies') as mock_discrepancies:
             with mock.patch.object(self.n57_obj, 'browse') as mock_browse:
                 norma57_file = mock.Mock()
                 norma57_file.name = 'Norma57 test'
@@ -142,4 +156,108 @@ class TestNorma57File(testing.OOTestCaseWithCursor):
         self.assertTrue(result)
         mock_sync.assert_called_once_with(
             self.cursor, self.uid, 'norma57.file', 'write', norma57_id, context={}
+        )
+
+    def test_get_payment_entry_erp_id_uses_offset(self):
+        self.assertEqual(self.n57_obj._get_payment_entry_erp_id(17), 900000017)
+
+    def test_sync_norma57_payment_entry_if_needed_skips_when_entry_already_exists(self):
+        norma57_id = self._create_norma57_file()
+        sync_id = self._create_norma57_sync(norma57_id)
+        self.sync_obj.write(self.cursor, self.uid, [sync_id], {
+            'pnt_norma57_payment_entry_odoo_id': 888,
+        })
+
+        result = self.n57_obj._sync_norma57_payment_entry_if_needed(
+            self.cursor, self.uid, norma57_id)
+
+        self.assertEqual(result, 888)
+
+    def test_sync_norma57_payment_entry_if_needed_stores_created_odoo_id(self):
+        norma57_id = self._create_norma57_file()
+        sync_id = self._create_norma57_sync(norma57_id)
+
+        with mock.patch.object(self.n57_obj, '_build_payment_entry_payload') as mock_payload:
+            with mock.patch.object(self.n57_obj, '_create_payment_entry_in_odoo') as mock_create:
+                mock_payload.return_value = {'pnt_erp_id': 900000001}
+                mock_create.return_value = {
+                    'success': True,
+                    'odoo_id': 4321,
+                    'response_text': '{"ok": true}',
+                    'url': 'http://odoo/api/v1/entries',
+                }
+
+                result = self.n57_obj._sync_norma57_payment_entry_if_needed(
+                    self.cursor, self.uid, norma57_id)
+
+        sync_record = self.sync_obj.browse(self.cursor, self.uid, sync_id)
+        self.assertEqual(result, 4321)
+        self.assertEqual(sync_record.pnt_norma57_payment_entry_odoo_id, 4321)
+        self.assertEqual(sync_record.pnt_norma57_payment_entry_last_result, '{"ok": true}')
+
+    def test_sync_norma57_payment_entry_if_needed_recovers_duplicate_entry_odoo_id(self):
+        norma57_id = self._create_norma57_file()
+        sync_id = self._create_norma57_sync(norma57_id)
+
+        with mock.patch.object(self.n57_obj, '_build_payment_entry_payload') as mock_payload:
+            with mock.patch.object(self.n57_obj, '_create_payment_entry_in_odoo') as mock_create:
+                with mock.patch.object(
+                        self.n57_obj,
+                        '_get_existing_payment_entry_odoo_id') as mock_get:
+                    mock_payload.return_value = {'pnt_erp_id': 900000001}
+                    mock_create.return_value = {
+                        'success': False,
+                        'odoo_id': False,
+                        'response_text': '{"error_code": "DUPLICATE_KEY_VALUE"}',
+                        'url': 'http://odoo/api/v1/entries',
+                    }
+                    mock_get.return_value = 7654
+
+                    result = self.n57_obj._sync_norma57_payment_entry_if_needed(
+                        self.cursor, self.uid, norma57_id)
+
+        sync_record = self.sync_obj.browse(self.cursor, self.uid, sync_id)
+        self.assertEqual(result, 7654)
+        self.assertEqual(sync_record.pnt_norma57_payment_entry_odoo_id, 7654)
+        self.assertEqual(
+            sync_record.pnt_norma57_payment_entry_last_result,
+            '{"error_code": "DUPLICATE_KEY_VALUE"}'
+        )
+
+    def test_sync_norma57_payment_entry_if_needed_stores_last_result_on_error(self):
+        norma57_id = self._create_norma57_file()
+        sync_id = self._create_norma57_sync(norma57_id)
+
+        with mock.patch.object(self.n57_obj, '_build_payment_entry_payload') as mock_payload:
+            with mock.patch.object(self.n57_obj, '_create_payment_entry_in_odoo') as mock_create:
+                mock_payload.return_value = {'pnt_erp_id': 900000001}
+                mock_create.return_value = {
+                    'success': False,
+                    'odoo_id': False,
+                    'response_text': 'boom',
+                    'url': 'http://odoo/api/v1/entries',
+                }
+
+                result = self.n57_obj._sync_norma57_payment_entry_if_needed(
+                    self.cursor, self.uid, norma57_id)
+
+        sync_record = self.sync_obj.browse(self.cursor, self.uid, sync_id)
+        self.assertFalse(result)
+        self.assertFalse(sync_record.pnt_norma57_payment_entry_odoo_id)
+        self.assertEqual(sync_record.pnt_norma57_payment_entry_last_result, 'boom')
+
+    @mock.patch.object(odoo_sync.OdooSync, 'poll_payment_order_status_sync')
+    def test_update_pending_state_sync_triggers_payment_entry_sync_after_poll(
+            self, mock_poll):
+        norma57_id = self._create_norma57_file()
+        mock_poll.return_value = True
+
+        with mock.patch.object(
+                type(self.n57_obj),
+                '_sync_norma57_payment_entry_if_needed') as mock_payment_entry_sync:
+            result = self.n57_obj.update_pending_state_sync(self.cursor, self.uid, norma57_id)
+
+        self.assertTrue(result)
+        mock_payment_entry_sync.assert_called_once_with(
+            self.cursor, self.uid, norma57_id, context={}
         )

--- a/som_sync_openerp/tests/tests_norma57_file.py
+++ b/som_sync_openerp/tests/tests_norma57_file.py
@@ -269,16 +269,20 @@ class TestNorma57File(testing.OOTestCaseWithCursor):
 
         with mock.patch.object(self.n57_obj, '_build_payment_entry_payload') as mock_payload:
             with mock.patch.object(self.n57_obj, '_create_payment_entry_in_odoo') as mock_create:
-                mock_payload.return_value = {'pnt_erp_id': 900000001}
-                mock_create.return_value = {
-                    'success': False,
-                    'odoo_id': False,
-                    'response_text': 'boom',
-                    'url': 'http://odoo/api/v1/entries',
-                }
+                with mock.patch.object(
+                        self.n57_obj,
+                        '_get_existing_payment_entry_odoo_id') as mock_get:
+                    mock_payload.return_value = {'pnt_erp_id': 900000001}
+                    mock_create.return_value = {
+                        'success': False,
+                        'odoo_id': False,
+                        'response_text': 'boom',
+                        'url': 'http://odoo/api/v1/entries',
+                    }
+                    mock_get.return_value = False
 
-                result = self.n57_obj._sync_norma57_payment_entry_if_needed(
-                    self.cursor, self.uid, norma57_id)
+                    result = self.n57_obj._sync_norma57_payment_entry_if_needed(
+                        self.cursor, self.uid, norma57_id)
 
         sync_record = self.sync_obj.browse(self.cursor, self.uid, sync_id)
         self.assertFalse(result)

--- a/som_sync_openerp/tests/tests_payment_order.py
+++ b/som_sync_openerp/tests/tests_payment_order.py
@@ -640,8 +640,16 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
     @mock.patch('som_sync_openerp.models.odoo_sync.OdooSync.update_odoo_id')
     @mock.patch('som_sync_openerp.models.odoo_sync.requests.get')
     @mock.patch.object(odoo_sync.OdooSync, "_get_conn_params")
+    @mock.patch(
+        'som_sync_openerp.models.norma57_file.Norma57File.'
+        '_sync_norma57_payment_entry_if_needed'
+    )
     def test_update_pending_state_marks_record_as_synced(
-        self, mock_get_conn_params, mock_requests_get, mock_update_odoo_id
+        self,
+        mock_payment_entry_sync,
+        mock_get_conn_params,
+        mock_requests_get,
+        mock_update_odoo_id,
     ):
         mock_get_conn_params.return_value = (
             'http://example.com/api/',
@@ -685,6 +693,7 @@ class TestPaymentOrder(testing.OOTestCaseWithCursor):
             'sync_state': 'synced',
             'update_last_sync': True,
         })
+        self.assertFalse(mock_payment_entry_sync.called)
 
     @mock.patch('som_sync_openerp.models.odoo_sync.OdooSync.update_odoo_id')
     @mock.patch('som_sync_openerp.models.odoo_sync.requests.get')


### PR DESCRIPTION
## Goal
Add the missing migration script for the new Norma57 payment-entry sync fields and config in `som_sync_openerp`.

## Instructions
- Keep the implementation in `som_sync_openerp`.
- Follow the existing migration pattern used by the module.

## Discoveries
- This module keeps post-migration scripts under `migrations/5.0.25.5.0/` and typically uses `_auto_init()` plus `load_data(..., mode='update')`.
- The new feature needed a migration because existing databases would not get the `odoo.sync` columns or the new config parameter automatically enough for safe upgrades.

## Accomplished
- ✅ Inspected the existing migration convention in `som_sync_openerp`.
- ✅ Added `post-0008_add_norma57_payment_entry_sync_fields.py` to initialize the new `odoo.sync` fields and reload `data/som_sync_openerp_data.xml`.
- ✅ Validated the new migration script syntax with Python 2 `py_compile`.

## Next Steps
- Run the module upgrade in a real database so the migration executes.
- Re-run the module tests once PostgreSQL is available locally.

## Relevant Files
- som_sync_openerp_modules/som_sync_openerp/migrations/5.0.25.5.0/post-0008_add_norma57_payment_entry_sync_fields.py — creates the new `odoo.sync` fields and reloads module config data.
- som_sync_openerp_modules/som_sync_openerp/models/odoo_sync.py — declares the new fields used by the migration.
- som_sync_openerp_modules/som_sync_openerp/data/som_sync_openerp_data.xml — contains the new `odoo_norma57_payment_entry_journal` config parameter.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/som_sync_openerp_modules/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds Norma57 payment-entry synchronization to `som_sync_openerp`. The main changes are:

- Creates balanced payment entries after remittance synchronization.
- Recovers existing entries after failed or conflicting create requests.
- Restores pending state when entry creation fails or raises an exception.
- Adds sync metadata fields and destination-journal configuration.
- Adds the migration and tests for existing installations.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- Failed create responses now trigger an authoritative lookup for an existing entry.
- Returned failures and raised exceptions both restore the sync record to pending.
- No blocking issue remains in the changed paths.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_sync_openerp/models/norma57_file.py | Adds payment-entry creation, duplicate recovery, and retry-state restoration for Norma57 remittances. |
| som_sync_openerp/models/odoo_sync.py | Adds the account-move mapping and fields used to track payment-entry synchronization. |
| som_sync_openerp/migrations/5.0.25.5.0/post-0008_add_norma57_payment_entry_sync_fields.py | Initializes the new sync fields and reloads module configuration during upgrades. |
| som_sync_openerp/data/som_sync_openerp_data.xml | Adds the destination-journal configuration for Norma57 payment entries. |
| som_sync_openerp/tests/tests_norma57_file.py | Covers entry creation, duplicate recovery, stored results, and retry handling. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix greptile review"](https://github.com/som-energia/som_sync_openerp_modules/commit/9bf0263c64a957c63fcbf5b57456d62221f822c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43791500)</sub>

<!-- /greptile_comment -->