### PR TITLE
feat(norma57): send source model in payment payload

### DIFF
--- a/som_sync_openerp/models/norma57_file.py
+++ b/som_sync_openerp/models/norma57_file.py
@@ -22,6 +22,7 @@ class Norma57File(osv.osv):
     MAPPING_FK = {}
     MAPPING_CONSTANTS = {
         'batch_type': 'inbound',
+        'pnt_source_model': 'norma57.file',
     }
 
     def get_mapping_model_post(self, cr, uid, id, context=None):

--- a/som_sync_openerp/tests/tests_norma57_file.py
+++ b/som_sync_openerp/tests/tests_norma57_file.py
@@ -58,6 +58,7 @@ class TestNorma57File(testing.OOTestCaseWithCursor):
             'name': 'Norma57 test',
             'sdd_required_collection_date': '2026-01-15',
             'amount': 125.5,
+            'pnt_source_model': 'norma57.file',
             'lines': [{
                 'invoice_id': 99,
                 'amount': 125.5,

--- a/som_sync_openerp/tests/tests_norma57_file.py
+++ b/som_sync_openerp/tests/tests_norma57_file.py
@@ -58,7 +58,6 @@ class TestNorma57File(testing.OOTestCaseWithCursor):
             'name': 'Norma57 test',
             'sdd_required_collection_date': '2026-01-15',
             'amount': 125.5,
-            'pnt_source_model': 'norma57.file',
             'lines': [{
                 'invoice_id': 99,
                 'amount': 125.5,
@@ -68,6 +67,30 @@ class TestNorma57File(testing.OOTestCaseWithCursor):
             self.cursor, self.uid, [invoice_id], [{'invoice_id': 99, 'amount': 125.5}],
             is_grouped=False, context={}
         )
+
+    @mock.patch.object(odoo_sync.OdooSync, 'common_sync_model_create_update')
+    def test_get_model_vals_to_sync_includes_norma57_source_model(self, mock_sync):
+        invoice_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, 'som_sync_openerp', 'invoice_0004'
+        )[1]
+        norma57_id = self._create_norma57_file()
+        mock_line = self._build_mock_line(invoice_id, amount=125.5)
+        self.conf_obj.set(self.cursor, self.uid, 'odoo_norma57_destination_journal', '17')
+        self.conf_obj.set(self.cursor, self.uid, 'odoo_norma57_payment_method', '411')
+        mock_sync.return_value = (99, invoice_id)
+
+        with mock.patch.object(type(self.ai_obj), 'process_lines_with_discrepancies'):
+            with mock.patch.object(self.n57_obj, 'browse') as mock_browse:
+                norma57_file = mock.Mock()
+                norma57_file.name = 'Norma57 test'
+                norma57_file.header_presentation_date = '2026-01-15'
+                norma57_file.lines = [mock_line]
+                mock_browse.return_value = norma57_file
+                payload = self.openerp.pool.get('odoo.sync').get_model_vals_to_sync(
+                    self.cursor, self.uid, 'norma57.file', norma57_id)
+
+        self.assertEqual(payload['pnt_source_model'], 'norma57.file')
+        self.assertEqual(payload['batch_type'], 'inbound')
 
     def test_get_line_invoice_erp_id_raises_when_resource_is_not_supported(self):
         line = mock.Mock()


### PR DESCRIPTION
Related to puntsistemes/som-energia_odoo#95

## Summary
- mark Norma57 payment-order payloads with `pnt_source_model = norma57.file`
- keep the producer change minimal so Odoo can distinguish N57 remittances on the shared `/api/v1/payment_orders` endpoint

## Changes
| File | Change |
|------|--------|
| `som_sync_openerp/models/norma57_file.py` | Add `pnt_source_model` to Norma57 payload constants |
| `som_sync_openerp/tests/tests_norma57_file.py` | Assert the payload includes the new marker |

## Test Plan
- [x] `python -m py_compile som_sync_openerp/models/norma57_file.py som_sync_openerp/tests/tests_norma57_file.py`
- [ ] Full OpenERP test suite not run locally in this session

## Notes
This PR is the producer-side companion to the Odoo implementation in `puntsistemes/som-energia_odoo#95`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/som_sync_openerp_modules/pull/51?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `pnt_source_model: 'norma57.file'` to `MAPPING_CONSTANTS` so that Odoo can distinguish Norma57 remittances from other payment orders on the shared `/api/v1/payment_orders` endpoint. The implementation placement is correct — constants in `MAPPING_CONSTANTS` are merged into the outgoing API payload by `get_model_vals_to_sync` in `odoo_sync.py`.

- **`norma57_file.py`**: One-line addition to `MAPPING_CONSTANTS`; the constant will be included in every sync payload sent to Odoo, consistent with how `batch_type` is handled.
- **`tests_norma57_file.py`**: The new assertion places `pnt_source_model` inside the expected return value of `get_related_values`, but that method does not return constants — they are merged downstream. The test will fail as written.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

The production model change is correct, but the updated test will fail and should not be merged as-is.

The constant is placed correctly in MAPPING_CONSTANTS and will appear in every outgoing Odoo payload. However, the test directly calls get_related_values and asserts pnt_source_model in its return value — a key that method never returns. Constants are only merged into the payload later inside get_model_vals_to_sync. The test will fail on any CI run, so the PR needs a fix to the assertion before it can land safely.

som_sync_openerp/tests/tests_norma57_file.py — the expected dict in test_get_related_values_builds_simple_payment_order_payload needs to be corrected.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| som_sync_openerp/models/norma57_file.py | Adds pnt_source_model: norma57.file to MAPPING_CONSTANTS; change is correct — MAPPING_CONSTANTS are merged into the API payload by get_model_vals_to_sync in odoo_sync.py |
| som_sync_openerp/tests/tests_norma57_file.py | Asserts pnt_source_model in the return value of get_related_values, but that method does not return constants — they are merged downstream in get_model_vals_to_sync. The test will fail as written. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant ERP as OpenERP
    participant NS as Norma57File.confirm()
    participant OS as OdooSync.get_model_vals_to_sync()
    participant Odoo as Odoo API /payment_orders

    ERP->>NS: confirm(norma57_id)
    NS->>OS: common_sync_model_create_update()
    OS->>NS: "get_related_values() returns {name, amount, lines, ...}"
    Note over OS: result_data.update(related_values)
    OS->>OS: "MAPPING_CONSTANTS = {batch_type, pnt_source_model}"
    Note over OS: result_data.update(MAPPING_CONSTANTS)
    OS->>Odoo: POST /payment_orders with pnt_source_model norma57.file
    Odoo-->>OS: "201 Created {odoo_id}"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant ERP as OpenERP
    participant NS as Norma57File.confirm()
    participant OS as OdooSync.get_model_vals_to_sync()
    participant Odoo as Odoo API /payment_orders

    ERP->>NS: confirm(norma57_id)
    NS->>OS: common_sync_model_create_update()
    OS->>NS: "get_related_values() returns {name, amount, lines, ...}"
    Note over OS: result_data.update(related_values)
    OS->>OS: "MAPPING_CONSTANTS = {batch_type, pnt_source_model}"
    Note over OS: result_data.update(MAPPING_CONSTANTS)
    OS->>Odoo: POST /payment_orders with pnt_source_model norma57.file
    Odoo-->>OS: "201 Created {odoo_id}"
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `som_sync_openerp/tests/tests_norma57_file.py`, line 55-66 ([link](https://github.com/som-energia/som_sync_openerp_modules/blob/c3f35abdffe64489cc8e757b6549fac822d98453/som_sync_openerp/tests/tests_norma57_file.py#L55-L66)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Test asserts field that `get_related_values` never returns**

   `get_related_values` in `norma57_file.py` does not include `pnt_source_model` in its return dict (lines 133–140). Constants from `MAPPING_CONSTANTS` are merged into the final sync payload only later, inside `get_model_vals_to_sync` in `odoo_sync.py` (lines 224–229). Because `get_related_values` is called directly here, the assertEqual will fail: the actual dict has no `pnt_source_model` key, while the expected dict does. The existing `batch_type` constant is similarly absent from this test’s expected dict for the same reason, which confirms the pattern. The fix is to remove `pnt_source_model` from the expected dict in this assertion, or to verify the full payload by calling `get_model_vals_to_sync` instead.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(norma57): send source model in paym..."](https://github.com/som-energia/som_sync_openerp_modules/commit/c3f35abdffe64489cc8e757b6549fac822d98453) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44430692)</sub>

<!-- /greptile_comment -->