### PR TITLE
🐛 avoid sync partner address without partner_id

### DIFF
--- a/som_sync_openerp/models/res_partner_address.py
+++ b/som_sync_openerp/models/res_partner_address.py
@@ -40,6 +40,10 @@ class ResPartnerAddress(osv.osv):
         'is_company': False,
     }
 
+    def check_special_restrictions(self, cr, uid, id, context=None):
+        address = self.browse(cr, uid, id, context=context)
+        return bool(address.partner_id)
+
     def get_related_values(self, cr, uid, id, context=None):
         if context is None:
             context = {}

--- a/som_sync_openerp/tests/tests_res_partner_address.py
+++ b/som_sync_openerp/tests/tests_res_partner_address.py
@@ -47,6 +47,26 @@ class TestResPartnerAddress(testing.OOTestCaseWithCursor):
 
         self.sync_obj.syncronize.assert_not_called()
 
+    def test__create_with_partner_triggers_sync(self):
+        partner_id = self.imd_obj.get_object_reference(
+            self.cursor, self.uid, 'base', 'res_partner_asus'
+        )[1]
+        _orig_sync_model_enabled_amplified = getattr(
+            self.sync_obj, 'sync_model_enabled_amplified', None)
+        self.sync_obj.sync_model_enabled_amplified = MagicMock(return_value=(True, True, True))
+        self.addCleanup(lambda orig=_orig_sync_model_enabled_amplified: setattr(
+            self.sync_obj, 'sync_model_enabled_amplified', orig))
+        _orig_syncronize = getattr(self.sync_obj, 'syncronize', None)
+        self.sync_obj.syncronize = MagicMock()
+        self.addCleanup(lambda orig=_orig_syncronize: setattr(self.sync_obj, 'syncronize', orig))
+
+        self.rpa_obj.create(self.cursor, self.uid, {
+            'partner_id': partner_id,
+            'nv': 'New Street Name',
+        })
+
+        self.sync_obj.syncronize.assert_called_once()
+
     def test__create__autosync_not_enabled_no_trigger(self):
         # sync_model_enabled_amplified returns (sync_enabled, auto_sync, async_enabled)
         _orig_sync_model_enabled_amplified = getattr(

--- a/som_sync_openerp/tests/tests_res_partner_address.py
+++ b/som_sync_openerp/tests/tests_res_partner_address.py
@@ -25,7 +25,7 @@ class TestResPartnerAddress(testing.OOTestCaseWithCursor):
         suffix = self.rpa_obj.get_endpoint_suffix(self.cursor, self.uid, partner_address_id)
         self.assertEqual(suffix, "contact/4001/invoice")
 
-    def test__create_triggers_sync(self):
+    def test__create_without_partner_does_not_trigger_sync(self):
         # sync_model_enabled_amplified returns (sync_enabled, auto_sync, async_enabled)
         _orig_sync_model_enabled_amplified = getattr(
             self.sync_obj, 'sync_model_enabled_amplified', None)
@@ -45,7 +45,7 @@ class TestResPartnerAddress(testing.OOTestCaseWithCursor):
             },
         )
 
-        self.sync_obj.syncronize.assert_called_once()
+        self.sync_obj.syncronize.assert_not_called()
 
     def test__create__autosync_not_enabled_no_trigger(self):
         # sync_model_enabled_amplified returns (sync_enabled, auto_sync, async_enabled)


### PR DESCRIPTION
## Goal
Prevent synchronizing partner addresses that lack an assigned partner.

## Discoveries
- Partner-address payload data and endpoint construction require `partner_id`.
- The central sync dispatcher honors per-model `check_special_restrictions`, preventing queue creation for ineligible records.

## Accomplished
- ✅ Added `ResPartnerAddress.check_special_restrictions()` to allow synchronization only with `partner_id`.
- ✅ Changed the parentless-create test to assert that no job is scheduled.
- ✅ Ran Python 2 compilation and `git diff --check` successfully.
- 🔲 Destral was not run because the user said they will run tests.

## Next Steps
- Run `TestResPartnerAddress` with Destral and commit/push if approved.

## Relevant Files
- som_sync_openerp_modules/som_sync_openerp/models/res_partner_address.py - parent eligibility restriction.
- som_sync_openerp_modules/som_sync_openerp/tests/tests_res_partner_address.py - parentless autosync regression test.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Som-Energia/som_sync_openerp_modules/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR guards against syncing `res.partner.address` records that have no `partner_id`, which would cause downstream failures (endpoint construction and `get_related_values` both require a linked partner). The fix follows the existing `check_special_restrictions` pattern used by other models in this codebase.

- **Model** (`res_partner_address.py`): Adds `check_special_restrictions` that returns `bool(address.partner_id)`, consistent with how `account_move.py`, `payment_order.py`, and `norma57_file.py` implement the same hook.
- **Tests** (`tests_res_partner_address.py`): Renames the original create test to the negative case (no partner → no sync) and adds a new positive test (`test__create_with_partner_triggers_sync`) using `res_partner_asus` demo data, addressing the gap flagged in a previous review round.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, targeted guard that follows the established pattern in this codebase and is covered by both a negative and a positive test.

The new method is a single boolean check consistent with how every other model in this repo implements the same hook. The dispatcher in odoo_sync.py already handles the method correctly. Both the no-partner and with-partner create paths are now tested. No existing behavior is altered.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_sync_openerp/models/res_partner_address.py | Adds check_special_restrictions returning bool(address.partner_id), correctly blocking sync for parentless addresses; follows the established pattern in other models. |
| som_sync_openerp/tests/tests_res_partner_address.py | Splits the former positive create test into a negative case (assert_not_called) and a new positive case (assert_called_once) with a real partner reference; full coverage of both paths. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App
    participant ResPartnerAddress
    participant OdooSync

    App->>ResPartnerAddress: create(vals)
    ResPartnerAddress->>ResPartnerAddress: super().create()
    ResPartnerAddress->>OdooSync: common_sync_model_create_update(model, 'create', id)
    OdooSync->>OdooSync: sync_model_enabled_amplified()
    alt sync_enabled AND auto_sync
        OdooSync->>OdooSync: hasattr(model, 'check_special_restrictions')?
        OdooSync->>ResPartnerAddress: check_special_restrictions(id)
        ResPartnerAddress->>ResPartnerAddress: browse(id).partner_id
        alt partner_id is set
            ResPartnerAddress-->>OdooSync: True
            OdooSync->>OdooSync: syncronize(model, 'create', id)
        else partner_id is missing
            ResPartnerAddress-->>OdooSync: False
            OdooSync->>OdooSync: log skip and continue
        end
    end
    ResPartnerAddress-->>App: id
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App
    participant ResPartnerAddress
    participant OdooSync

    App->>ResPartnerAddress: create(vals)
    ResPartnerAddress->>ResPartnerAddress: super().create()
    ResPartnerAddress->>OdooSync: common_sync_model_create_update(model, 'create', id)
    OdooSync->>OdooSync: sync_model_enabled_amplified()
    alt sync_enabled AND auto_sync
        OdooSync->>OdooSync: hasattr(model, 'check_special_restrictions')?
        OdooSync->>ResPartnerAddress: check_special_restrictions(id)
        ResPartnerAddress->>ResPartnerAddress: browse(id).partner_id
        alt partner_id is set
            ResPartnerAddress-->>OdooSync: True
            OdooSync->>OdooSync: syncronize(model, 'create', id)
        else partner_id is missing
            ResPartnerAddress-->>OdooSync: False
            OdooSync->>OdooSync: log skip and continue
        end
    end
    ResPartnerAddress-->>App: id
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix greptile review"](https://github.com/som-energia/som_sync_openerp_modules/commit/4cf8ed2a2e7bf93a701bd2ab42e1e5761adc62e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45936386)</sub>

<!-- /greptile_comment -->